### PR TITLE
Fix EXIF extraction on modern Pillow, search pagination totals, and no-filter browsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
+__pycache__/
 *.json
 ex-images
 sm-images
 .venv
 .idea
-256-images
+256-imagesthumbnail_cache

--- a/README.md
+++ b/README.md
@@ -61,8 +61,14 @@ pip install -r requirements.txt
 2. Run the processing pipeline:
 
 ```bash
-python main_load.py
+python main_load.py --images-dir 256-images --db-uri data/photos-256 --faces-dir cropped_faces_256
 ```
+
+By default this is **incremental**: rerunning it only indexes images that
+aren't in the database yet. New faces are matched against known people (by
+face-encoding distance to each person's stored centroid) and genuinely new
+faces become new people. Use `--rebuild` to drop the database and reprocess
+everything from scratch.
 
 3. Start the API server:
 
@@ -78,10 +84,23 @@ The system provides REST API endpoints for:
 - Semantic image search using natural language queries
 - Face-based photo search
 - Temporal search and filtering
-- Individual photo retrieval
-- Person management (naming, merging identities)
+- Individual photo retrieval (originals, cached thumbnails, full metadata)
+- Visually similar image lookup (`/images/{id}/similar`)
+- Library statistics (`/stats`)
+- Person management (naming, merging identities, deletion)
 
 See the OpenAPI specification for detailed endpoint documentation.
+
+### Server configuration
+
+The API server reads these environment variables (all optional):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PHOTO_DB_URI` | `data/photos-256` | LanceDB database location |
+| `PHOTO_FACES_DIR` | `cropped_faces_256` | Cropped face images directory |
+| `PHOTO_THUMBNAIL_CACHE_DIR` | `thumbnail_cache` | On-disk thumbnail cache |
+| `PHOTO_CORS_ORIGINS` | `http://localhost:3000` | Comma-separated allowed CORS origins |
 
 ## Database Schema
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,17 @@ connectivity is required. Your personal photos stay private.
 
 ## System Components
 
-- `main.py`: Core orchestration script for processing images and managing the database
+- `main.py`: FastAPI application exposing the search and photo-management REST API
+- `main_load.py`: Core orchestration script for processing images and populating the database
+- `run.py`: Development server entry point (uvicorn, auto-reload)
+- `production.py`: Production server entry point (gunicorn with uvicorn workers)
 - `get_emb.py`: CLIP model integration for semantic embeddings
 - `get_exif.py`: EXIF data extraction utilities
 - `proc_imgs.py`: Face detection and processing pipeline
+
+A companion web UI lives in a separate repository:
+[T-Lind/photo-library-frontend](https://github.com/T-Lind/photo-library-frontend) (expected at
+`http://localhost:3000`, which is the origin allowed by the API's CORS configuration).
 
 ## Requirements
 
@@ -55,6 +62,13 @@ pip install -r requirements.txt
 
 ```bash
 python main_load.py
+```
+
+3. Start the API server:
+
+```bash
+python run.py         # development (auto-reload, http://localhost:5000)
+python production.py  # production (gunicorn, http://0.0.0.0:8000)
 ```
 
 ## API Endpoints

--- a/get_emb.py
+++ b/get_emb.py
@@ -1,22 +1,51 @@
-from transformers import CLIPProcessor, CLIPModel
 import torch
 from PIL import Image
+from transformers import CLIPModel, CLIPProcessor
 
-model = CLIPModel.from_pretrained("openai/clip-vit-base-patch16")
-processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch16")
+MODEL_NAME = "openai/clip-vit-base-patch16"
+
+
+def _pick_device():
+    if torch.cuda.is_available():
+        return "cuda"
+    mps = getattr(torch.backends, "mps", None)
+    if mps is not None and mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+DEVICE = _pick_device()
+
+model = CLIPModel.from_pretrained(MODEL_NAME).to(DEVICE).eval()
+processor = CLIPProcessor.from_pretrained(MODEL_NAME)
+
+
+def get_image_embeddings(image_paths):
+    """Embed a batch of images in a single forward pass.
+
+    Returns a list of embedding lists, in the same order as image_paths.
+    """
+    images = []
+    try:
+        for path in image_paths:
+            with Image.open(path) as img:
+                images.append(img.convert("RGB"))
+
+        inputs = processor(images=images, return_tensors="pt").to(DEVICE)
+        with torch.inference_mode():
+            embeddings = model.get_image_features(**inputs)
+        return embeddings.cpu().numpy().tolist()
+    finally:
+        for img in images:
+            img.close()
 
 
 def get_image_embedding(image_path):
-    image = Image.open(image_path)
-    inputs = processor(images=image, return_tensors="pt", padding=True)
-    with torch.no_grad():
-        embeddings = model.get_image_features(**inputs)
-    return embeddings.cpu().numpy().flatten().tolist()
+    return get_image_embeddings([image_path])[0]
+
 
 def get_text_embedding(query):
-    inputs = processor(text=query, return_tensors="pt", padding=True)
-    with torch.no_grad():
+    inputs = processor(text=query, return_tensors="pt", padding=True).to(DEVICE)
+    with torch.inference_mode():
         embeddings = model.get_text_features(**inputs)
     return embeddings.cpu().numpy().flatten().tolist()
-
-

--- a/get_exif.py
+++ b/get_exif.py
@@ -1,88 +1,75 @@
-from PIL import Image
 import io
-import pyheif
-import exifread
 import re
-from PIL.ExifTags import TAGS, GPSTAGS
+
+import exifread
+import pyheif
+from PIL import Image
+
+# EXIF IFD pointers and tag IDs
+EXIF_IFD = 0x8769
+GPS_IFD = 0x8825
+DATETIME_ORIGINAL = 36867
+DATETIME = 306
+
+GPS_LATITUDE_REF = 1
+GPS_LATITUDE = 2
+GPS_LONGITUDE_REF = 3
+GPS_LONGITUDE = 4
 
 
-def latlng_conversion(latlng, ref):
-    degrees = latlng[0][0] / latlng[0][1]
-    minutes = latlng[1][0] / latlng[1][1] / 60.0
-    seconds = latlng[2][0] / latlng[2][1] / 3600.0
-
-    if ref in ['S', 'W']:
+def latlng_conversion(dms, ref):
+    """Convert EXIF degree/minute/second rationals to signed decimal degrees."""
+    degrees = float(dms[0]) + float(dms[1]) / 60.0 + float(dms[2]) / 3600.0
+    if ref in ('S', 'W'):
         degrees = -degrees
-        minutes = -minutes
-        seconds = -seconds
-
-    return round(degrees + minutes + seconds, 5)
+    return round(degrees, 5)
 
 
-def get_coordinates(geotags):
-    lat = latlng_conversion(geotags['GPSLatitude'], geotags['GPSLatitudeRef'])
+def get_coordinates(gps_ifd):
+    lat = gps_ifd.get(GPS_LATITUDE)
+    lat_ref = gps_ifd.get(GPS_LATITUDE_REF)
+    lon = gps_ifd.get(GPS_LONGITUDE)
+    lon_ref = gps_ifd.get(GPS_LONGITUDE_REF)
 
-    lon = latlng_conversion(geotags['GPSLongitude'], geotags['GPSLongitudeRef'])
+    if not (lat and lat_ref and lon and lon_ref):
+        return ""
 
-    return (lat, lon)
-
-
-def get_geotagging(exif):
-    if not exif:
-        return None
-        # raise ValueError("No EXIF metadata found")
-
-    geotagging = {}
-    for (idx, tag) in TAGS.items():
-        if tag == 'GPSInfo':
-            if idx not in exif:
-                return None
-                # raise ValueError("No EXIF geotagging found")
-
-            for (key, val) in GPSTAGS.items():
-                if key in exif[idx]:
-                    geotagging[val] = exif[idx][key]
-    return geotagging
+    return (latlng_conversion(lat, lat_ref), latlng_conversion(lon, lon_ref))
 
 
 def get_exif_data(ifile):
-    if re.search(r'jpeg$|bmp$|png$|jpg$', str(ifile), re.IGNORECASE):
-        image = Image.open(ifile)
-        exifdata = image.getexif()
-        geotags = get_geotagging(exifdata)
-        try:
-            if "{1:" in str(exifdata[34853]):
-                lat_long = get_coordinates(geotags)
-                # geo_loc = get_location(str(lat_long)[1:-1])
-                geo_loc = lat_long
+    ifile = str(ifile)
+    if re.search(r'\.(jpe?g|bmp|png)$', ifile, re.IGNORECASE):
+        with Image.open(ifile) as image:
+            exifdata = image.getexif()
 
-            else:
-                geo_loc = ""  # No loc data
-        except KeyError as e:
+        # DateTimeOriginal lives in the Exif sub-IFD; fall back to the
+        # base-IFD DateTime tag if it's missing.
+        date = exifdata.get_ifd(EXIF_IFD).get(DATETIME_ORIGINAL) or exifdata.get(DATETIME)
+
+        try:
+            geo_loc = get_coordinates(exifdata.get_ifd(GPS_IFD))
+        except (TypeError, ValueError, ZeroDivisionError):
             geo_loc = ""
 
-        return exifdata.get(36867), geo_loc
-    elif re.search(r'heic$', str(ifile), re.IGNORECASE):
-        # this part of the decision tree processes HEIC files
-
-        heif_file = pyheif.read(str(ifile))
-        for metadata in heif_file.metadata:
-
+        return date, geo_loc
+    elif re.search(r'\.hei[cf]$', ifile, re.IGNORECASE):
+        heif_file = pyheif.read(ifile)
+        for metadata in heif_file.metadata or []:
             if metadata['type'] == 'Exif':
                 fstream = io.BytesIO(metadata['data'][6:])
+                tags = exifread.process_file(fstream, details=False)
+                date = tags.get('EXIF DateTimeOriginal')
+                return (str(date) if date else None), ""
 
-        tags = exifread.process_file(fstream, details=False)
+        return None, ""
+    elif re.search(r'\.(cr2|nef)$', ifile, re.IGNORECASE):
+        # Raw files (Canon and Nikon)
+        with open(ifile, 'rb') as f:
+            tags = exifread.process_file(f, details=False)
 
-        return str(tags.get('EXIF DateTimeOriginal')), ""
-    elif re.search(r'CR2$|NEF$', str(ifile), re.IGNORECASE):
-        # this part of the decision tree processes raw files (Cannon and Nikon)
-        f = open(ifile, 'rb')
-
-        # Return Exif tags
-        tags = exifread.process_file(f, details=False)
-        orig_date = tags['EXIF DateTimeOriginal']
-
-        return str(orig_date)[:10], ""
+        date = tags.get('EXIF DateTimeOriginal')
+        return (str(date) if date else None), ""
 
     else:
         raise ValueError("File type not supported (doesn't seem to be an image)!")

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from pydantic import BaseModel, Field
 import lancedb
 import pandas as pd
+import pyarrow.compute as pc
 from pathlib import Path
 import logging
 from get_emb import get_text_embedding
@@ -23,22 +24,19 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Initialize FastAPI app
-app = FastAPI(title="Photo Search API")
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["http://localhost:3000"],  # Frontend URL
-    allow_credentials=True,
-    allow_methods=["*"],  # Allows all methods
-    allow_headers=["*"],  # Allows all headers
-)
+# Configuration (overridable via environment variables)
+DB_URI = os.environ.get("PHOTO_DB_URI", "data/photos-256")
+FACE_IMAGES_DIR = os.environ.get("PHOTO_FACES_DIR", "cropped_faces_256")
+THUMBNAIL_CACHE_DIR = os.environ.get("PHOTO_THUMBNAIL_CACHE_DIR", "thumbnail_cache")
+CORS_ORIGINS = os.environ.get("PHOTO_CORS_ORIGINS", "http://localhost:3000").split(",")
 
-# Configuration
-DB_URI = "data/photos-256"
-FACE_IMAGES_DIR = "cropped_faces_256"
 IMAGES_PER_PAGE = 20
 NUM_PROBES = 20  # For vector search
 REFINE_FACTOR = 10  # For vector search refinement
+
+# Columns returned to clients; excludes the 512-dim embedding vectors so we
+# never pull them out of the database for plain result listing.
+IMAGE_RESULT_COLUMNS = ["image_id", "image_path", "people_ids", "date", "location"]
 
 THUMBNAIL_SIZES = {
     "small": (150, 150),
@@ -46,14 +44,24 @@ THUMBNAIL_SIZES = {
     "large": (500, 500)
 }
 
+# Initialize FastAPI app
+app = FastAPI(title="Photo Search API")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=CORS_ORIGINS,
+    allow_credentials=True,
+    allow_methods=["*"],  # Allows all methods
+    allow_headers=["*"],  # Allows all headers
+)
+
 
 class SearchRequest(BaseModel):
     query: Optional[str] = None
     start_date: Optional[str] = Field(None, description="ISO format date string")
     end_date: Optional[str] = Field(None, description="ISO format date string")
     people_ids: Optional[List[int]] = None
-    page: int = 1
-    per_page: int = IMAGES_PER_PAGE
+    page: int = Field(1, ge=1)
+    per_page: int = Field(IMAGES_PER_PAGE, ge=1, le=100)
 
 
 class Person(BaseModel):
@@ -70,6 +78,15 @@ class SearchResults(BaseModel):
     results: List[dict]
 
 
+class UpdatePersonRequest(BaseModel):
+    name: str
+
+
+class MergePeopleRequest(BaseModel):
+    source_id: int
+    target_id: int
+
+
 def get_db():
     """Database connection factory"""
     try:
@@ -78,6 +95,48 @@ def get_db():
     except Exception as e:
         logger.error(f"Failed to connect to database: {e}")
         raise HTTPException(status_code=500, detail="Database connection failed")
+
+
+def format_image_date(value):
+    """ISO-format a stored timestamp; None for missing/epoch-garbage dates"""
+    if pd.notnull(value) and isinstance(value, pd.Timestamp) and value.year > 1970:
+        return value.isoformat()
+    return None
+
+
+def row_to_image(row):
+    """Convert an images-table row to the API's Image representation"""
+    people_ids = row["people_ids"]
+    if not isinstance(people_ids, list):
+        people_ids = list(people_ids) if people_ids is not None else []
+
+    return {
+        "image_id": int(row["image_id"]),
+        "date": format_image_date(row["date"]),
+        "location": row["location"] if pd.notnull(row["location"]) else "",
+        "people_ids": [int(pid) for pid in people_ids],
+        "thumbnail_url": f"/api/v1/images/{int(row['image_id'])}/thumbnail"
+    }
+
+
+def person_photo_count(images_table, people_id: int) -> int:
+    return images_table.count_rows(f"array_contains(people_ids, {people_id})")
+
+
+def person_exists(people_table, people_id: int) -> bool:
+    return people_table.count_rows(f"people_id = {people_id}") > 0
+
+
+def get_person_name(people_table, people_id: int) -> Optional[str]:
+    df = (
+        people_table.search()
+        .where(f"people_id = {people_id}")
+        .limit(1)
+        .to_pandas()
+    )
+    if df.empty:
+        return None
+    return df.iloc[0]["name"]
 
 
 @app.post("/api/v1/search", response_model=SearchResults)
@@ -141,43 +200,63 @@ async def search_photos(search_request: SearchRequest):
             if where_clause:
                 search = search.where(where_clause)
 
+        # LanceDB 0.14 silently ignores offset() on non-vector queries, so
+        # fetch the first offset+per_page rows (cheap: small columns only,
+        # no vectors) and slice off the earlier pages.
         results_df = (
             search
-            .limit(search_request.per_page)
-            .offset(offset)
+            .select(IMAGE_RESULT_COLUMNS)
+            .limit(offset + search_request.per_page)
             .to_pandas()
+            .iloc[offset:]
         )
-
-        # Format results according to API schema
-        results = []
-        for _, row in results_df.iterrows():
-            date_value = row["date"]
-            formatted_date = None
-
-            # Only format valid dates after 1970
-            if pd.notnull(date_value) and isinstance(date_value, pd.Timestamp):
-                if date_value.year > 1970:
-                    formatted_date = date_value.isoformat()
-                else:
-                    formatted_date = None
-
-            results.append({
-                "image_id": int(row["image_id"]),
-                "date": formatted_date,  # Will be None for invalid/null dates
-                "location": row["location"] if pd.notnull(row["location"]) else "",
-                "people_ids": row["people_ids"].tolist() if isinstance(row["people_ids"], (list, pd.Series)) else [],
-                "thumbnail_url": f"/api/v1/images/{row['image_id']}/thumbnail"
-            })
 
         return SearchResults(
             total=total_count,
             page=search_request.page,
             per_page=search_request.per_page,
-            results=results
+            results=[row_to_image(row) for _, row in results_df.iterrows()]
         )
 
     except Exception as e:
         logger.error(f"Search failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/api/v1/stats")
+async def get_stats():
+    """
+    Library-wide statistics: image/people counts and the covered date range.
+    """
+    try:
+        db = get_db()
+        images_table = db["images"]
+        people_table = db["people"]
+
+        total_images = images_table.count_rows(None)
+        total_people = people_table.count_rows(None)
+        images_with_location = images_table.count_rows("location != ''")
+
+        earliest = latest = None
+        if total_images:
+            # Read only the date column, never the embedding vectors
+            dates = images_table.to_lance().to_table(columns=["date"])["date"]
+            min_date, max_date = pc.min(dates).as_py(), pc.max(dates).as_py()
+            if min_date is not None:
+                earliest = min_date.isoformat()
+            if max_date is not None:
+                latest = max_date.isoformat()
+
+        return {
+            "total_images": total_images,
+            "total_people": total_people,
+            "images_with_location": images_with_location,
+            "earliest_date": earliest,
+            "latest_date": latest,
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to compute stats: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -191,18 +270,9 @@ async def get_person(people_id: int):
         people_table = db["people"]
         images_table = db["images"]
 
-        # Get person details
-        person_df = people_table.to_pandas()
-        person = person_df[person_df["people_id"] == people_id]
-
-        if person.empty:
+        name = get_person_name(people_table, people_id)
+        if name is None:
             raise HTTPException(status_code=404, detail="Person not found")
-
-        # Count photos with this person
-        images_df = images_table.to_pandas()
-        photo_count = len(images_df[
-                              images_df["people_ids"].apply(lambda x: people_id in x)
-                          ])
 
         # Check if face image exists
         face_path = Path(FACE_IMAGES_DIR) / f"person_{people_id}.jpg"
@@ -211,8 +281,8 @@ async def get_person(people_id: int):
 
         return Person(
             people_id=people_id,
-            name=person.iloc[0]["name"],
-            photo_count=photo_count,
+            name=name,
+            photo_count=person_photo_count(images_table, people_id),
             face_image_url=f"/api/v1/people/{people_id}/face"
         )
 
@@ -234,8 +304,6 @@ async def get_person_face(people_id: int):
 
     return FileResponse(face_path, media_type="image/jpeg")
 
-class UpdatePersonRequest(BaseModel):
-    name: str
 
 @app.patch("/api/v1/people/{people_id}")
 async def update_person(people_id: int, request: UpdatePersonRequest = Body(...)):
@@ -246,19 +314,15 @@ async def update_person(people_id: int, request: UpdatePersonRequest = Body(...)
         db = get_db()
         people_table = db.open_table("people")
 
-        people_df = people_table.to_pandas()
-        if people_df[people_df["people_id"] == people_id].empty:
+        if not person_exists(people_table, people_id):
             raise HTTPException(status_code=404, detail="Person not found")
 
         people_table.update(where=f"people_id = {people_id}", values={"name": request.name})
 
-        images_df = db.open_table("images").to_pandas()
-        photo_count = int(images_df["people_ids"].apply(lambda x: people_id in x).sum())
-
         return Person(
             people_id=people_id,
             name=request.name,
-            photo_count=photo_count,
+            photo_count=person_photo_count(db.open_table("images"), people_id),
             face_image_url=f"/api/v1/people/{people_id}/face"
         )
 
@@ -266,6 +330,117 @@ async def update_person(people_id: int, request: UpdatePersonRequest = Body(...)
         raise
     except Exception as e:
         logger.error(f"Failed to update person: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+def remove_person_from_images(images_table, people_id: int, replacement_id: Optional[int] = None) -> int:
+    """Remove (or replace) a person id in every image's people_ids list.
+
+    Returns the number of affected images.
+    """
+    affected_count = person_photo_count(images_table, people_id)
+    if affected_count == 0:
+        return 0
+
+    affected = (
+        images_table.search()
+        .where(f"array_contains(people_ids, {people_id})")
+        .select(["image_id", "people_ids"])
+        .limit(affected_count)
+        .to_pandas()
+    )
+
+    for _, row in affected.iterrows():
+        ids = {int(pid) for pid in row["people_ids"]}
+        ids.discard(people_id)
+        if replacement_id is not None:
+            ids.add(replacement_id)
+        where = f"image_id = {int(row['image_id'])}"
+        if ids:
+            images_table.update(where=where, values={"people_ids": sorted(ids)})
+        else:
+            # An empty Python list can't be type-inferred by update();
+            # make_array() writes a typed empty list instead.
+            images_table.update(where=where, values_sql={"people_ids": "make_array()"})
+
+    return affected_count
+
+
+@app.post("/api/v1/people/merge")
+async def merge_people(request: MergePeopleRequest):
+    """
+    Merge two person entries (for when the same person was detected as two
+    different people). All of source's photos are re-attributed to target,
+    then the source person is removed.
+    """
+    try:
+        if request.source_id == request.target_id:
+            raise HTTPException(status_code=400, detail="Cannot merge a person into themselves")
+
+        db = get_db()
+        people_table = db["people"]
+        images_table = db["images"]
+
+        target_name = get_person_name(people_table, request.target_id)
+        if target_name is None:
+            raise HTTPException(status_code=404, detail="Target person not found")
+        if not person_exists(people_table, request.source_id):
+            raise HTTPException(status_code=404, detail="Source person not found")
+
+        remove_person_from_images(images_table, request.source_id, replacement_id=request.target_id)
+        people_table.delete(f"people_id = {request.source_id}")
+
+        # Remove the now-orphaned face crop of the source person
+        source_face = Path(FACE_IMAGES_DIR) / f"person_{request.source_id}.jpg"
+        if source_face.exists():
+            source_face.unlink()
+
+        return Person(
+            people_id=request.target_id,
+            name=target_name,
+            photo_count=person_photo_count(images_table, request.target_id),
+            face_image_url=f"/api/v1/people/{request.target_id}/face"
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to merge people: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.delete("/api/v1/people/{people_id}")
+async def delete_person(people_id: int, permanent: bool = Query(False)):
+    """
+    Delete a person: removes them from all images and from the people table.
+    With permanent=true, their cropped face image is also deleted from disk.
+    """
+    try:
+        db = get_db()
+        people_table = db["people"]
+        images_table = db["images"]
+
+        if not person_exists(people_table, people_id):
+            raise HTTPException(status_code=404, detail="Person not found")
+
+        affected = remove_person_from_images(images_table, people_id)
+        people_table.delete(f"people_id = {people_id}")
+
+        if permanent:
+            face_path = Path(FACE_IMAGES_DIR) / f"person_{people_id}.jpg"
+            if face_path.exists():
+                face_path.unlink()
+
+        return {
+            "success": True,
+            "message": f"Person {people_id} {'permanently deleted' if permanent else 'deleted'}",
+            "affected_images": affected,
+        }
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to delete person: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -279,22 +454,20 @@ async def list_people():
         people_table = db["people"]
         images_table = db["images"]
 
-        # Get all people
+        # Get all people (small table)
         people_df = people_table.to_pandas()
 
-        # Get image counts for each person using a single pass through the images table
-        images_df = images_table.to_pandas()
-
-        # Calculate photo counts for all people at once
+        # Count photos per person in one pass over just the people_ids
+        # column — the embedding vectors never leave the database.
         photo_counts = {}
-        for _, row in images_df.iterrows():
-            for person_id in row["people_ids"]:
+        for ids in images_table.to_lance().to_table(columns=["people_ids"])["people_ids"].to_pylist():
+            for person_id in ids or []:
                 photo_counts[person_id] = photo_counts.get(person_id, 0) + 1
 
         # Build the response
         people_list = []
         for _, person in people_df.iterrows():
-            person_id = person["people_id"]
+            person_id = int(person["people_id"])
 
             # Check if face image exists
             face_path = Path(FACE_IMAGES_DIR) / f"person_{person_id}.jpg"
@@ -319,76 +492,32 @@ async def list_people():
         raise HTTPException(status_code=500, detail=str(e))
 
 
+def get_image_row(image_id: int, db, columns: List[str]):
+    """Fetch selected columns of one images-table row, or 404."""
+    result = (
+        db["images"].search()
+        .where(f"image_id = {image_id}")
+        .select(columns)
+        .limit(1)
+        .to_pandas()
+    )
+
+    if result.empty:
+        raise HTTPException(status_code=404, detail="Image not found")
+
+    return result.iloc[0]
+
+
 def get_image_path(image_id: int, db) -> str:
     """Get the image path from the database for a given image ID."""
     try:
-        table = db["images"]
-        result = (
-            table.search()
-            .where(f"image_id = {image_id}")
-            .limit(1)
-            .to_pandas()
-        )
-
-        if result.empty:
-            raise HTTPException(status_code=404, detail="Image not found")
-
-        return result.iloc[0]["image_path"]
+        return get_image_row(image_id, db, ["image_path"])["image_path"]
     except HTTPException:
         raise
     except Exception as e:
         logger.error(f"Failed to get image path: {e}")
         raise HTTPException(status_code=500, detail="Database error")
 
-
-def create_thumbnail(image_path: str, size: tuple) -> str:
-    """
-    Create a thumbnail of the specified size while maintaining aspect ratio.
-    Supports both regular image formats and HEIC files.
-    Returns path to temporary thumbnail file.
-    """
-    try:
-        # Check if file exists
-        if not os.path.exists(image_path):
-            raise FileNotFoundError(f"Image file not found: {image_path}")
-
-        with Image.open(image_path) as img:
-            # Convert to RGB if necessary (e.g., for PNGs with transparency or HEIC)
-            if img.mode in ('RGBA', 'P', 'CMYK'):
-                img = img.convert('RGB')
-
-            # Calculate new dimensions maintaining aspect ratio
-            orig_width, orig_height = img.size
-            target_width, target_height = size
-
-            # Calculate aspect ratios
-            aspect = orig_width / orig_height
-            target_aspect = target_width / target_height
-
-            if aspect > target_aspect:
-                # Image is wider than target
-                new_width = target_width
-                new_height = int(target_width / aspect)
-            else:
-                # Image is taller than target
-                new_height = target_height
-                new_width = int(target_height * aspect)
-
-            # Resize with high-quality antialiasing
-            img = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
-
-            # Create temporary file for thumbnail
-            temp_file = tempfile.NamedTemporaryFile(delete=False, suffix='.jpg')
-            img.save(temp_file.name, "JPEG", quality=85, optimize=True)
-
-            return temp_file.name
-
-    except Exception as e:
-        logger.error(f"Failed to create thumbnail for {image_path}: {str(e)}")
-        raise HTTPException(
-            status_code=500,
-            detail=f"Thumbnail creation failed: {str(e)}"
-        )
 
 @app.get("/api/v1/images/{image_id}")
 async def get_original_image(image_id: int):
@@ -402,7 +531,6 @@ async def get_original_image(image_id: int):
 
         return FileResponse(
             image_path,
-            media_type="image/jpeg",  # Adjust if you need to handle other formats
             filename=f"image_{image_id}{Path(image_path).suffix}"
         )
 
@@ -411,6 +539,110 @@ async def get_original_image(image_id: int):
     except Exception as e:
         logger.error(f"Failed to get image: {e}")
         raise HTTPException(status_code=500, detail="Failed to retrieve image")
+
+
+@app.get("/api/v1/images/{image_id}/details")
+async def get_image_details(image_id: int):
+    """Full metadata for one image, with resolved people names."""
+    try:
+        db = get_db()
+        row = get_image_row(image_id, db, IMAGE_RESULT_COLUMNS)
+
+        image = row_to_image(row)
+        image["image_url"] = f"/api/v1/images/{image_id}"
+        image["similar_url"] = f"/api/v1/images/{image_id}/similar"
+        image["filename"] = Path(row["image_path"]).name
+
+        # Resolve people names (people table is small)
+        people_df = db["people"].to_pandas()
+        names = dict(zip(people_df["people_id"].astype(int), people_df["name"]))
+        image["people"] = [
+            {
+                "people_id": pid,
+                "name": names.get(pid, ""),
+                "face_image_url": f"/api/v1/people/{pid}/face",
+            }
+            for pid in image["people_ids"]
+        ]
+
+        return image
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to get image details: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@app.get("/api/v1/images/{image_id}/similar")
+async def get_similar_images(image_id: int, limit: int = Query(12, ge=1, le=100)):
+    """Find visually similar images using the stored CLIP embedding."""
+    try:
+        db = get_db()
+        row = get_image_row(image_id, db, ["vector"])
+
+        results_df = (
+            db["images"].search(list(row["vector"]))
+            .nprobes(NUM_PROBES)
+            .refine_factor(REFINE_FACTOR)
+            .where(f"image_id != {image_id}", prefilter=True)
+            .select(IMAGE_RESULT_COLUMNS)
+            .limit(limit)
+            .to_pandas()
+        )
+
+        return {"results": [row_to_image(r) for _, r in results_df.iterrows()]}
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Failed to find similar images: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+def get_or_create_thumbnail(image_id: int, image_path: str, size_name: str) -> str:
+    """
+    Return a cached thumbnail path, generating it on first request.
+
+    Thumbnails are cached on disk keyed by image id and size, and
+    regenerated if the source image is newer than the cached file.
+    JPEG sources use draft-mode decoding, which decodes directly to a
+    reduced resolution instead of loading the full image into memory.
+    """
+    cache_dir = Path(THUMBNAIL_CACHE_DIR) / size_name
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_path = cache_dir / f"{image_id}.jpg"
+
+    if cache_path.exists() and cache_path.stat().st_mtime >= os.path.getmtime(image_path):
+        return str(cache_path)
+
+    size = THUMBNAIL_SIZES[size_name]
+    try:
+        with Image.open(image_path) as img:
+            img.draft("RGB", size)  # Fast reduced-resolution decode (JPEG only, no-op otherwise)
+            if img.mode not in ("RGB", "L"):
+                img = img.convert("RGB")
+            img.thumbnail(size, Image.Resampling.LANCZOS)
+
+            # Write atomically so a concurrent request never sees a partial file
+            fd, tmp_path = tempfile.mkstemp(suffix=".jpg", dir=cache_dir)
+            os.close(fd)
+            try:
+                img.save(tmp_path, "JPEG", quality=85, optimize=True)
+                os.replace(tmp_path, cache_path)
+            except BaseException:
+                if os.path.exists(tmp_path):
+                    os.unlink(tmp_path)
+                raise
+
+        return str(cache_path)
+
+    except Exception as e:
+        logger.error(f"Failed to create thumbnail for {image_path}: {str(e)}")
+        raise HTTPException(
+            status_code=500,
+            detail=f"Thumbnail creation failed: {str(e)}"
+        )
 
 
 @app.get("/api/v1/images/{image_id}/thumbnail")
@@ -426,21 +658,12 @@ async def get_image_thumbnail(
         if not os.path.exists(image_path):
             raise HTTPException(status_code=404, detail="Image file not found")
 
-        # Create thumbnail
-        thumbnail_path = create_thumbnail(image_path, THUMBNAIL_SIZES[size])
-
-        # Use FileResponse with cleanup callback
-        def cleanup_thumbnail():
-            try:
-                os.unlink(thumbnail_path)
-            except:
-                pass
+        thumbnail_path = get_or_create_thumbnail(image_id, image_path, size)
 
         return FileResponse(
             thumbnail_path,
             media_type="image/jpeg",
             filename=f"thumbnail_{image_id}.jpg",
-            background=cleanup_thumbnail
         )
 
     except HTTPException:
@@ -448,18 +671,3 @@ async def get_image_thumbnail(
     except Exception as e:
         logger.error(f"Failed to get thumbnail: {e}")
         raise HTTPException(status_code=500, detail="Failed to create thumbnail")
-
-
-# Optional: Add a cleanup route for temporary files
-@app.on_event("shutdown")
-async def cleanup_temp_files():
-    """Clean up any remaining temporary thumbnail files on shutdown."""
-    temp_dir = tempfile.gettempdir()
-    try:
-        for file in Path(temp_dir).glob("*thumbnail_*.jpg"):
-            try:
-                os.unlink(file)
-            except:
-                pass
-    except Exception as e:
-        logger.error(f"Failed to clean up temporary files: {e}")

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI, HTTPException, Query, Body
 from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional
-from datetime import date, datetime
+from datetime import datetime
 from pydantic import BaseModel, Field
 import lancedb
 import pandas as pd
@@ -80,21 +80,6 @@ def get_db():
         raise HTTPException(status_code=500, detail="Database connection failed")
 
 
-def apply_filters(query: pd.DataFrame, start_date: Optional[date],
-                  end_date: Optional[date], people_ids: Optional[List[int]]) -> pd.DataFrame:
-    """Apply date and people filters to search results"""
-    if start_date:
-        query = query[query['date'] >= pd.Timestamp(start_date)]
-    if end_date:
-        query = query[query['date'] <= pd.Timestamp(end_date)]
-    if people_ids:
-        # Filter for images containing any of the specified people
-        query = query[query['people_ids'].apply(
-            lambda x: any(pid in x for pid in people_ids)
-        )]
-    return query
-
-
 @app.post("/api/v1/search", response_model=SearchResults)
 async def search_photos(search_request: SearchRequest):
     """
@@ -131,6 +116,10 @@ async def search_photos(search_request: SearchRequest):
         # Combine all conditions with AND
         where_clause = " AND ".join(where_conditions) if where_conditions else None
 
+        # Total matches: a vector search ranks every row that passes the
+        # filter, so the filtered row count is the total for both paths.
+        total_count = images_table.count_rows(where_clause)
+
         # Calculate pagination
         offset = (search_request.page - 1) * search_request.per_page
 
@@ -139,41 +128,25 @@ async def search_photos(search_request: SearchRequest):
             # Get embedding for semantic search
             query_emb = get_text_embedding(search_request.query)
 
-            # Build and execute search with prefiltering
-            if where_clause:
-                results = (
-                    images_table.search(query_emb)
-                    .where(where_clause, prefilter=True)
-                )
-            else:
-                results = images_table.search(query_emb)
-
-            # Get total count first
-            total_count = len(results.to_arrow())
-
-            # Then get paginated results
-            results_df = (
-                results
-                .limit(search_request.per_page)
-                .offset(offset)
-                .to_pandas()
+            search = (
+                images_table.search(query_emb)
+                .nprobes(NUM_PROBES)
+                .refine_factor(REFINE_FACTOR)
             )
+            if where_clause:
+                search = search.where(where_clause, prefilter=True)
         else:
             # No semantic search, just filtering and pagination
-            query = images_table
+            search = images_table.search()
             if where_clause:
-                query = query.search().where(where_clause)
+                search = search.where(where_clause)
 
-            # Get total count
-            total_count = len(query.to_arrow())
-
-            # Get paginated results
-            results_df = (
-                query
-                .limit(search_request.per_page)
-                .offset(offset)
-                .to_pandas()
-            )
+        results_df = (
+            search
+            .limit(search_request.per_page)
+            .offset(offset)
+            .to_pandas()
+        )
 
         # Format results according to API schema
         results = []
@@ -271,18 +244,21 @@ async def update_person(people_id: int, request: UpdatePersonRequest = Body(...)
     """
     try:
         db = get_db()
-        images_table = db.open_table("images")
-
-        images_df = images_table.to_pandas()
-
         people_table = db.open_table("people")
 
+        people_df = people_table.to_pandas()
+        if people_df[people_df["people_id"] == people_id].empty:
+            raise HTTPException(status_code=404, detail="Person not found")
 
         people_table.update(where=f"people_id = {people_id}", values={"name": request.name})
+
+        images_df = db.open_table("images").to_pandas()
+        photo_count = int(images_df["people_ids"].apply(lambda x: people_id in x).sum())
+
         return Person(
             people_id=people_id,
             name=request.name,
-            photo_count=-1,
+            photo_count=photo_count,
             face_image_url=f"/api/v1/people/{people_id}/face"
         )
 
@@ -336,7 +312,6 @@ async def list_people():
 
         # Sort by photo count descending, then by name
         people_list.sort(key=lambda x: (-x.photo_count, x.name))
-        print("People list", people_list)
         return people_list
 
     except Exception as e:
@@ -359,6 +334,8 @@ def get_image_path(image_id: int, db) -> str:
             raise HTTPException(status_code=404, detail="Image not found")
 
         return result.iloc[0]["image_path"]
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Failed to get image path: {e}")
         raise HTTPException(status_code=500, detail="Database error")

--- a/main_load.py
+++ b/main_load.py
@@ -1,10 +1,12 @@
+import argparse
 import lancedb
 import pyarrow as pa
+import pyarrow.compute as pc
 from tqdm import tqdm
 from datetime import datetime
-from get_emb import get_image_embedding
+from get_emb import get_image_embeddings
 from get_exif import get_exif_data
-from proc_imgs import process_faces
+from proc_imgs import process_faces, process_new_faces
 import os
 import logging
 
@@ -15,7 +17,9 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 DIMS = 512
 NUM_PARTITIONS = 16
 NUM_SUB_VECTORS = 8
-BATCH_SIZE = 100
+BATCH_SIZE = 100  # Rows per database insert
+EMBED_BATCH_SIZE = 16  # Images per CLIP forward pass
+MIN_ROWS_FOR_INDEX = 256  # Below this, brute-force search is fine (and PQ training fails)
 SAVES_DIR = "saves"  # Directory for saved face processing results
 
 SUPPORTED_FORMATS = {'.png', '.jpg', '.jpeg', '.heic', '.heif'}
@@ -26,10 +30,13 @@ def is_supported_image(filename):
     return any(filename.lower().endswith(ext) for ext in SUPPORTED_FORMATS)
 
 
-def setup_database(uri):
-    """Set up the LanceDB database and tables"""
-    db = lancedb.connect(uri)
+def list_image_files(folder_path):
+    return [f for f in os.listdir(folder_path)
+            if is_supported_image(f) and 'cropped_faces' not in f]
 
+
+def setup_database(db):
+    """Create (or recreate) the people and images tables"""
     # Create people table
     people_schema = pa.schema([
         pa.field("people_id", pa.int32()),
@@ -54,41 +61,79 @@ def setup_database(uri):
         pa.field("location", pa.string()),
     ])
     imgs_tbl = db.create_table("images", schema=imgs_schema)
-    return db, people_tbl, imgs_tbl
+    return people_tbl, imgs_tbl
 
 
-def process_images(folder_path, image_to_people, batch_size=100):
-    """Process images and yield batches for database insertion"""
-    image_id = 0
+def get_existing_state(imgs_tbl):
+    """Return (already-indexed image paths, next free image_id).
+
+    Reads only the two small columns, never the embedding vectors.
+    """
+    table = imgs_tbl.to_lance().to_table(columns=["image_path", "image_id"])
+    paths = set(table["image_path"].to_pylist())
+    max_id = pc.max(table["image_id"]).as_py() if table.num_rows else None
+    return paths, (max_id + 1 if max_id is not None else 0)
+
+
+def read_image_metadata(image_path):
+    """EXIF date/location for one image; failures degrade to (None, "")."""
+    try:
+        date, location = get_exif_data(image_path)
+    except Exception as e:
+        logging.warning(f"Could not read EXIF from {image_path}: {str(e)}")
+        return None, ""
+
+    if date:
+        try:
+            date = datetime.strptime(str(date), '%Y:%m:%d %H:%M:%S')
+        except ValueError:
+            logging.warning(f"Could not parse date {date} for {image_path}")
+            date = None
+    else:
+        date = None
+
+    return date, location
+
+
+def process_images(folder_path, image_to_people, image_files, start_id=0,
+                   batch_size=BATCH_SIZE, embed_batch_size=EMBED_BATCH_SIZE):
+    """Process images (embedding in batches) and yield row batches for insertion"""
+    image_id = start_id
     batch = []
     failed_images = []
 
-    # Get list of all image files first
-    image_files = [f for f in os.listdir(folder_path) if is_supported_image(f) and 'cropped_faces' not in f]
+    progress = tqdm(total=len(image_files), desc="Processing images")
 
-    for image_name in tqdm(image_files, desc="Processing images"):
-        image_path = os.path.join(folder_path, image_name)
+    for chunk_start in range(0, len(image_files), embed_batch_size):
+        chunk = image_files[chunk_start:chunk_start + embed_batch_size]
+
+        # Gather per-image metadata first (cheap, failures don't skip the image)
+        metas = []
+        for image_name in chunk:
+            image_path = os.path.join(folder_path, image_name)
+            date, location = read_image_metadata(image_path)
+            metas.append((image_name, image_path, date, location))
+
+        # Embed the whole chunk in one forward pass; on failure fall back
+        # to per-image embedding so one bad file doesn't sink the chunk.
         try:
-            # Get EXIF data
-            date, location = get_exif_data(image_path)
-            if date:
+            vectors = get_image_embeddings([m[1] for m in metas])
+        except Exception:
+            vectors = []
+            for _, image_path, _, _ in metas:
                 try:
-                    date = datetime.strptime(date, '%Y:%m:%d %H:%M:%S')
-                except ValueError:
-                    logging.warning(f"Could not parse date {date} for {image_path}")
-                    date = None
+                    vectors.append(get_image_embeddings([image_path])[0])
+                except Exception as e:
+                    logging.error(f"Failed to get embedding for {image_path}: {str(e)}")
+                    vectors.append(None)
 
-            # Get image embedding
-            try:
-                vec = get_image_embedding(image_path)
-            except Exception as e:
-                logging.error(f"Failed to get embedding for {image_path}: {str(e)}")
+        for (image_name, image_path, date, location), vec in zip(metas, vectors):
+            progress.update(1)
+            if vec is None:
                 failed_images.append((image_path, "embedding_failed"))
                 continue
 
-            # Get people IDs for this image
-            people_ids = image_to_people.get(image_name, [])
-            people_ids = list(set(people_ids))  # remove duplicates
+            people_ids = sorted(set(image_to_people.get(image_name, [])))
 
             batch.append({
                 "image_id": image_id,
@@ -104,10 +149,7 @@ def process_images(folder_path, image_to_people, batch_size=100):
                 yield batch
                 batch = []
 
-        except Exception as e:
-            logging.error(f"Error processing {image_name}: {str(e)}")
-            failed_images.append((image_path, str(e)))
-            continue
+    progress.close()
 
     # Yield any remaining images in the last batch
     if batch:
@@ -120,14 +162,34 @@ def process_images(folder_path, image_to_people, batch_size=100):
             logging.warning(f"- {path}: {error}")
 
 
-def main(folder_path, faces_dir, db_uri):
-    """Main function to process images and populate the database"""
-    os.makedirs(SAVES_DIR, exist_ok=True)
+def build_index(imgs_tbl):
+    """Create the ANN index; fall back to brute-force search on failure"""
+    row_count = imgs_tbl.count_rows(None)
+    if row_count < MIN_ROWS_FOR_INDEX:
+        logging.info(
+            f"Only {row_count} rows; skipping ANN index (brute-force search is fast enough)")
+        return
 
+    logging.info("Creating vector similarity search index...")
+    try:
+        imgs_tbl.create_index(num_partitions=NUM_PARTITIONS, num_sub_vectors=NUM_SUB_VECTORS)
+    except Exception as e:
+        logging.warning(f"Index creation failed (search falls back to brute force): {str(e)}")
+
+
+def full_build(db, folder_path, faces_dir):
+    """Drop everything and reprocess the whole folder"""
     logging.info("Step 1: Setting up database...")
-    db, people_tbl, imgs_tbl = setup_database(db_uri)
+    people_tbl, imgs_tbl = setup_database(db)
 
-    logging.info("\nStep 2: Processing faces and clustering...")
+    # A full rebuild must not reuse stale cached face clusters, or images
+    # added since the cache was written would get no face assignments.
+    cache_path = os.path.join(SAVES_DIR, f"{os.path.basename(folder_path)}_face_data.json")
+    if os.path.exists(cache_path):
+        os.remove(cache_path)
+        logging.info("Cleared cached face data for full rebuild")
+
+    logging.info("Step 2: Processing faces and clustering...")
     image_to_people, label_to_person_id = process_faces(folder_path, faces_dir, SAVES_DIR)
 
     num_people = len(label_to_person_id)
@@ -143,22 +205,82 @@ def main(folder_path, faces_dir, db_uri):
 
     logging.info("Step 4: Processing images and populating images table...")
     total_processed = 0
-    for batch in process_images(folder_path, image_to_people, batch_size=BATCH_SIZE):
+    image_files = list_image_files(folder_path)
+    for batch in process_images(folder_path, image_to_people, image_files):
         imgs_tbl.add(batch)
         total_processed += len(batch)
 
     logging.info(f"Successfully processed {total_processed} images")
-
-    # Create index for vector similarity search
-    logging.info("Creating vector similarity search index...")
-    imgs_tbl.create_index(num_partitions=NUM_PARTITIONS, num_sub_vectors=NUM_SUB_VECTORS)
-
+    build_index(imgs_tbl)
     logging.info("Processing complete!")
+
+
+def incremental_update(db, folder_path, faces_dir):
+    """Add only images that aren't in the database yet"""
+    imgs_tbl = db.open_table("images")
+    people_tbl = db.open_table("people")
+
+    existing_paths, next_id = get_existing_state(imgs_tbl)
+    new_files = [f for f in list_image_files(folder_path)
+                 if os.path.join(folder_path, f) not in existing_paths]
+
+    if not new_files:
+        logging.info("No new images found; database is up to date.")
+        return
+
+    logging.info(f"Found {len(new_files)} new images (of "
+                 f"{len(existing_paths)} already indexed)")
+
+    logging.info("Step 1: Matching faces in new images against known people...")
+    try:
+        image_to_people, new_person_ids = process_new_faces(
+            new_files, folder_path, faces_dir, SAVES_DIR)
+    except RuntimeError as e:
+        logging.error(str(e))
+        return
+
+    if new_person_ids:
+        people_tbl.add([{"people_id": pid, "name": ""} for pid in new_person_ids])
+        logging.info(f"Added {len(new_person_ids)} new people")
+
+    logging.info("Step 2: Embedding and inserting new images...")
+    total_processed = 0
+    for batch in process_images(folder_path, image_to_people, new_files, start_id=next_id):
+        imgs_tbl.add(batch)
+        total_processed += len(batch)
+
+    logging.info(f"Added {total_processed} new images")
+    build_index(imgs_tbl)
+    logging.info("Incremental update complete!")
+
+
+def main(folder_path, faces_dir, db_uri, rebuild=False):
+    """Main entry point: full rebuild or incremental update"""
+    os.makedirs(SAVES_DIR, exist_ok=True)
+    db = lancedb.connect(db_uri)
+
+    has_tables = "images" in db.table_names() and "people" in db.table_names()
+    if rebuild or not has_tables:
+        if not has_tables and not rebuild:
+            logging.info("No existing database found; running a full build.")
+        full_build(db, folder_path, faces_dir)
+    else:
+        incremental_update(db, folder_path, faces_dir)
+
     return db
 
 
 if __name__ == "__main__":
-    folder_path = "256-images"
-    db_uri = "data/photos-256"
-    faces_dir = "cropped_faces_256"
-    main(folder_path, faces_dir, db_uri)
+    parser = argparse.ArgumentParser(description="Index a photo folder into LanceDB")
+    parser.add_argument("--images-dir", default="256-images",
+                        help="Folder containing the photos to index")
+    parser.add_argument("--db-uri", default="data/photos-256",
+                        help="LanceDB database location")
+    parser.add_argument("--faces-dir", default="cropped_faces_256",
+                        help="Directory for cropped face images")
+    parser.add_argument("--rebuild", action="store_true",
+                        help="Drop the database and reprocess everything "
+                             "(default is incremental: only new images are added)")
+    args = parser.parse_args()
+
+    main(args.images_dir, args.faces_dir, args.db_uri, rebuild=args.rebuild)

--- a/main_load.py
+++ b/main_load.py
@@ -1,7 +1,6 @@
 import lancedb
 import pyarrow as pa
 from tqdm import tqdm
-from transformers import CLIPProcessor, CLIPModel
 from datetime import datetime
 from get_emb import get_image_embedding
 from get_exif import get_exif_data
@@ -11,10 +10,6 @@ import logging
 
 # Configure logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
-
-# Load the CLIP model
-model = CLIPModel.from_pretrained("openai/clip-vit-base-patch32")
-processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
 
 # LITERALS
 DIMS = 512

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -112,6 +112,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/SearchResults'
 
+  /stats:
+    get:
+      summary: Library-wide statistics
+      responses:
+        '200':
+          description: Image/people counts and covered date range
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total_images:
+                    type: integer
+                  total_people:
+                    type: integer
+                  images_with_location:
+                    type: integer
+                  earliest_date:
+                    type: string
+                    format: date-time
+                    nullable: true
+                  latest_date:
+                    type: string
+                    format: date-time
+                    nullable: true
+
   /images/{image_id}:
     get:
       summary: Get original image
@@ -155,6 +181,76 @@ paths:
               schema:
                 type: string
                 format: binary
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /images/{image_id}/details:
+    get:
+      summary: Get full metadata for one image, with resolved people names
+      parameters:
+        - name: image_id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Image metadata
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/Image'
+                  - type: object
+                    properties:
+                      image_url:
+                        type: string
+                      similar_url:
+                        type: string
+                      filename:
+                        type: string
+                      people:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            people_id:
+                              type: integer
+                            name:
+                              type: string
+                            face_image_url:
+                              type: string
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /images/{image_id}/similar:
+    get:
+      summary: Find visually similar images using the stored CLIP embedding
+      parameters:
+        - name: image_id
+          in: path
+          required: true
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 12
+            minimum: 1
+            maximum: 100
+      responses:
+        '200':
+          description: Similar images, most similar first
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Image'
         '404':
           $ref: '#/components/responses/NotFound'
 
@@ -216,7 +312,8 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
     delete:
-      summary: Delete or hide a person
+      summary: Delete a person
+      description: Removes the person from all images and from the people table. With permanent=true, their cropped face image is also deleted from disk.
       parameters:
         - name: people_id
           in: path

--- a/proc_imgs.py
+++ b/proc_imgs.py
@@ -12,8 +12,15 @@ import logging
 # Register HEIF opener with Pillow
 register_heif_opener()
 
+SUPPORTED_FACE_FORMATS = ('.png', '.jpg', '.jpeg', '.heic', '.heif')
 
-def save_face_data(image_to_people, label_to_person_id, save_dir, folder_name):
+# Maximum face-encoding distance for a new face to be assigned to an
+# existing person during incremental indexing (same scale as DBSCAN eps).
+MATCH_THRESHOLD = 0.5
+
+
+def save_face_data(image_to_people, label_to_person_id, save_dir, folder_name,
+                   person_centroids=None):
     """Save face processing results to JSON file"""
     os.makedirs(save_dir, exist_ok=True)
     save_path = os.path.join(save_dir, f"{folder_name}_face_data.json")
@@ -21,7 +28,8 @@ def save_face_data(image_to_people, label_to_person_id, save_dir, folder_name):
     data = {
         "image_to_people": {k: list(v) if isinstance(v, set) else v
                             for k, v in image_to_people.items()},
-        "label_to_person_id": {str(k): v for k, v in label_to_person_id.items()}
+        "label_to_person_id": {str(k): v for k, v in label_to_person_id.items()},
+        "person_centroids": {str(k): list(v) for k, v in (person_centroids or {}).items()},
     }
 
     with open(save_path, 'w') as f:
@@ -34,16 +42,17 @@ def load_face_data(save_dir, folder_name):
     save_path = os.path.join(save_dir, f"{folder_name}_face_data.json")
 
     if not os.path.exists(save_path):
-        return None, None
+        return None, None, None
 
     with open(save_path, 'r') as f:
         data = json.load(f)
 
     # Convert label_to_person_id keys back to integers
     label_to_person_id = {int(k): v for k, v in data["label_to_person_id"].items()}
+    person_centroids = {int(k): np.array(v) for k, v in data.get("person_centroids", {}).items()}
 
     logging.info(f"Loaded face data from {save_path}")
-    return data["image_to_people"], label_to_person_id
+    return data["image_to_people"], label_to_person_id, person_centroids
 
 
 def convert_heic_to_jpg(heic_path):
@@ -96,11 +105,55 @@ def cluster_faces(encodings, threshold=0.5):
     return cluster_labels
 
 
+def encode_faces_in_image(image_path):
+    """Detect and encode all faces in one image.
+
+    Returns a list of (encoding, location) tuples. HEIC/HEIF files are
+    converted to a temporary JPEG for face_recognition, then cleaned up.
+    """
+    work_path = image_path
+    if image_path.lower().endswith(('.heic', '.heif')):
+        work_path = convert_heic_to_jpg(image_path)
+
+    try:
+        image = face_recognition.load_image_file(work_path)
+        face_locations = face_recognition.face_locations(image)
+        face_encodings = face_recognition.face_encodings(image, face_locations)
+        return list(zip(face_encodings, face_locations))
+    finally:
+        if work_path != image_path:
+            os.remove(work_path)
+
+
+def save_face_crop(image_path, location, face_filename):
+    """Save a cropped (padded) face image if it doesn't already exist."""
+    if os.path.exists(face_filename):
+        return
+
+    top, right, bottom, left = location
+    with Image.open(image_path) as img:
+        # Add 20% padding
+        height = bottom - top
+        width = right - left
+        padding_v = int(height * 0.2)
+        padding_h = int(width * 0.2)
+
+        top = max(0, top - padding_v)
+        bottom = bottom + padding_v
+        left = max(0, left - padding_h)
+        right = right + padding_h
+
+        face_img = img.crop((left, top, right, bottom))
+        if face_img.mode != 'RGB':
+            face_img = face_img.convert('RGB')
+        face_img.save(face_filename, "JPEG")
+
+
 def process_faces(folder_path, faces_dir="cropped_faces", save_dir="saves"):
     """Process all images in folder and return face clustering results"""
     # Try to load existing face data
     folder_name = os.path.basename(folder_path)
-    image_to_people, label_to_person_id = load_face_data(save_dir, folder_name)
+    image_to_people, label_to_person_id, _ = load_face_data(save_dir, folder_name)
 
     if image_to_people is not None and label_to_person_id is not None:
         logging.info("Using cached face processing results")
@@ -115,34 +168,17 @@ def process_faces(folder_path, faces_dir="cropped_faces", save_dir="saves"):
         image_path = os.path.join(folder_path, image_name)
 
         # Skip non-image files and the faces directory
-        if not image_path.lower().endswith(
-                ('.png', '.jpg', '.jpeg', '.heic', '.heif')) or 'cropped_faces' in image_path:
+        if not image_path.lower().endswith(SUPPORTED_FACE_FORMATS) or 'cropped_faces' in image_path:
             continue
 
         try:
-            # Convert HEIC images to JPG temporarily
-            original_path = image_path
-            if image_path.lower().endswith(('.heic', '.heif')):
-                image_path = convert_heic_to_jpg(image_path)
-
-            # Process image for face recognition
-            image = face_recognition.load_image_file(image_path)
-            face_locations = face_recognition.face_locations(image)
-            face_encodings = face_recognition.face_encodings(image, face_locations)
-
-            # Store encodings and metadata
-            for encoding, location in zip(face_encodings, face_locations):
+            for encoding, location in encode_faces_in_image(image_path):
                 image_encodings.append({
                     "encoding": encoding,
                     "image": image_name,
                     "location": location,
-                    "image_path": original_path
+                    "image_path": image_path
                 })
-
-            # Cleanup temporary files
-            if image_path != original_path:
-                os.remove(image_path)
-
         except Exception as e:
             logging.error(f"Error processing faces in {image_name}: {str(e)}")
             continue
@@ -150,6 +186,7 @@ def process_faces(folder_path, faces_dir="cropped_faces", save_dir="saves"):
     # Perform clustering if faces were found
     if not image_encodings:
         logging.warning("No faces found in any images")
+        save_face_data({}, {}, save_dir, folder_name, {})
         return {}, {}
 
     # Extract encodings for clustering
@@ -162,36 +199,106 @@ def process_faces(folder_path, faces_dir="cropped_faces", save_dir="saves"):
     image_to_people = defaultdict(set)  # Using set to avoid duplicates
     label_to_person_id = {label: idx for idx, label in enumerate(np.unique(labels))}
 
+    # Accumulate encodings per person so we can store a mean ("centroid")
+    # encoding, used later to match new faces during incremental indexing.
+    person_encodings = defaultdict(list)
+
     # Process clustering results
     for entry, label in zip(image_encodings, labels):
         person_id = label_to_person_id[label]
         image_name = entry['image']
         image_to_people[image_name].add(person_id)  # Using set to avoid duplicates
+        person_encodings[person_id].append(entry['encoding'])
 
         # Save the face image
         face_filename = os.path.join(faces_dir, f"person_{person_id}.jpg")
-        if not os.path.exists(face_filename):
-            top, right, bottom, left = entry['location']
-            with Image.open(entry['image_path']) as img:
-                # Add 20% padding
-                height = bottom - top
-                width = right - left
-                padding_v = int(height * 0.2)
-                padding_h = int(width * 0.2)
+        try:
+            save_face_crop(entry['image_path'], entry['location'], face_filename)
+        except Exception as e:
+            logging.error(f"Failed to save face crop for person {person_id}: {str(e)}")
 
-                top = max(0, top - padding_v)
-                bottom = bottom + padding_v
-                left = max(0, left - padding_h)
-                right = right + padding_h
-
-                face_img = img.crop((left, top, right, bottom))
-                face_img.save(face_filename, "JPEG")
+    person_centroids = {pid: np.mean(encs, axis=0)
+                        for pid, encs in person_encodings.items()}
 
     # Convert defaultdict and sets to regular dict and lists before saving
     image_to_people = {k: list(v) for k, v in image_to_people.items()}
 
     # Save the results
-    save_face_data(image_to_people, label_to_person_id, save_dir, folder_name)
+    save_face_data(image_to_people, label_to_person_id, save_dir, folder_name,
+                   person_centroids)
 
     logging.info(f"Found {len(label_to_person_id)} unique people across all images")
     return image_to_people, label_to_person_id
+
+
+def process_new_faces(new_image_names, folder_path, faces_dir="cropped_faces",
+                      save_dir="saves"):
+    """Incrementally process faces for new images only.
+
+    Each new face is assigned to the nearest existing person (by centroid
+    distance) if within MATCH_THRESHOLD; otherwise a new person is created.
+    Returns (image_to_people for the new images, list of newly created
+    person ids). Requires centroid data saved by a previous full run.
+    """
+    folder_name = os.path.basename(folder_path)
+    image_to_people, label_to_person_id, person_centroids = load_face_data(save_dir, folder_name)
+
+    if image_to_people is None:
+        raise RuntimeError(
+            "No cached face data found; run a full (re)build before indexing incrementally.")
+
+    if not person_centroids and label_to_person_id:
+        logging.warning(
+            "Cached face data has no centroid encodings (created by an older "
+            "version). New faces cannot be matched to existing people; "
+            "re-run with --rebuild to regenerate. Skipping face assignment.")
+        return {}, []
+
+    os.makedirs(faces_dir, exist_ok=True)
+
+    next_person_id = max(list(person_centroids.keys()) + [-1]) + 1
+    new_person_ids = []
+    new_image_to_people = {}
+
+    for image_name in tqdm(new_image_names, desc="Processing new faces"):
+        image_path = os.path.join(folder_path, image_name)
+        try:
+            faces = encode_faces_in_image(image_path)
+        except Exception as e:
+            logging.error(f"Error processing faces in {image_name}: {str(e)}")
+            continue
+
+        people = set()
+        for encoding, location in faces:
+            person_id = None
+            if person_centroids:
+                ids = list(person_centroids.keys())
+                dists = [np.linalg.norm(encoding - person_centroids[pid]) for pid in ids]
+                best = int(np.argmin(dists))
+                if dists[best] <= MATCH_THRESHOLD:
+                    person_id = ids[best]
+
+            if person_id is None:
+                person_id = next_person_id
+                next_person_id += 1
+                new_person_ids.append(person_id)
+                person_centroids[person_id] = np.array(encoding)
+                face_filename = os.path.join(faces_dir, f"person_{person_id}.jpg")
+                try:
+                    save_face_crop(image_path, location, face_filename)
+                except Exception as e:
+                    logging.error(f"Failed to save face crop for person {person_id}: {str(e)}")
+
+            people.add(person_id)
+
+        if people:
+            new_image_to_people[image_name] = sorted(people)
+
+    # Persist updated mappings so subsequent incremental runs see them
+    image_to_people.update(new_image_to_people)
+    save_face_data(image_to_people, label_to_person_id, save_dir, folder_name,
+                   person_centroids)
+
+    if new_person_ids:
+        logging.info(f"Created {len(new_person_ids)} new people from new images")
+    return new_image_to_people, new_person_ids

--- a/proc_imgs.py
+++ b/proc_imgs.py
@@ -49,7 +49,7 @@ def load_face_data(save_dir, folder_name):
 def convert_heic_to_jpg(heic_path):
     """Convert HEIC/HEIF to JPEG using pillow-heif"""
     with Image.open(heic_path) as image:
-        jpeg_path = heic_path.replace('.heic', '.jpg').replace('.HEIC', '.jpg')
+        jpeg_path = os.path.splitext(heic_path)[0] + '.jpg'
         image.save(jpeg_path, "JPEG")
         return jpeg_path
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ torch~=2.5.0
 pydantic~=2.9.2
 fastapi~=0.115.3
 uvicorn~=0.32.0
+gunicorn~=23.0.0

--- a/run.py
+++ b/run.py
@@ -4,7 +4,7 @@ from fastapi.staticfiles import StaticFiles
 from main import app
 
 # Configuration
-HOST = "localhost"  # This allows external access. Use "127.0.0.1" for local only
+HOST = "localhost"  # Local only. Use "0.0.0.0" to allow external access
 PORT = 5000
 DB_URI = "data/photos-256"  # LanceDB database location
 FACE_IMAGES_DIR = "cropped_faces_256"  # Directory for face images


### PR DESCRIPTION
- get_exif.py: read DateTimeOriginal from the Exif sub-IFD and GPS from the
  GPS IFD via getexif().get_ifd(). On Pillow 11 the old code always returned
  None for JPEG dates, and GPS-tagged JPEGs raised TypeError (the GPSInfo tag
  is now a raw offset int), which caused those images to be skipped entirely
  during indexing. Also handle IFDRational values, close the RAW file handle,
  guard HEIC files without EXIF blocks, and return None instead of "None"
  for missing dates.
- main.py /search: compute total via count_rows(filter) instead of
  len(results.to_arrow()), which was capped at the default vector-search
  limit of 10 and executed the query twice. Use the empty search builder for
  non-semantic browsing so requests with no query and no filters no longer
  crash (Table has no .limit()). Apply the previously unused NUM_PROBES /
  REFINE_FACTOR settings to vector searches.
- main.py: return the real photo count from PATCH /people (was -1), 404 on
  updating an unknown person, stop converting image-not-found 404s into 500s,
  drop a leftover print and the unused apply_filters helper.
- main_load.py: remove a duplicate module-level CLIP load (patch32) that was
  never used - get_emb.py already loads patch16.
- proc_imgs.py: convert .heif files too, not just .heic.
- requirements.txt: add gunicorn (production.py depends on it).
- run.py: fix backwards comment about the localhost bind.
- README: document the actual entry points and link the companion
  photo-library-frontend repo.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Sd3oUT4zTcLC1E5yGJ82Yw