### PR TITLE
Local OCR text search, albums with smart suggestions, paste-to-search

### DIFF
--- a/desktop/ui/app.css
+++ b/desktop/ui/app.css
@@ -259,6 +259,36 @@ button:disabled { cursor: not-allowed; opacity: .45; }
 .section-head h4 { margin: 0; font-size: 14.5px; }
 .section-hint { color: var(--faint); }
 
+/* -- collapsible panels ---------------------------------------------------------------------------- */
+.collapse-head { display: flex; align-items: center; gap: 10px; width: 100%; padding: 0; border: none; background: none; text-align: left; }
+.collapse-head h2 { margin: 0; font-size: 17px; }
+.collapse-chevron { color: var(--accent); font-size: 14px; width: 14px; }
+.collapse-count { margin-left: auto; color: var(--faint); }
+.collapse-copy { margin: 12px 0 14px; color: var(--muted); font-size: 13px; line-height: 1.55; }
+
+/* -- albums -------------------------------------------------------------------------------------------- */
+.album-create { display: flex; gap: 8px; }
+.albums-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 12px; }
+.album-card { display: flex; flex-direction: column; gap: 4px; padding: 0 0 12px; border: 1px solid var(--line-soft); border-radius: var(--radius-lg); background: var(--surface-2); overflow: hidden; text-align: left; }
+.album-card:hover { border-color: var(--accent); }
+.album-cover { display: block; width: 100%; aspect-ratio: 3 / 2; background: var(--surface); overflow: hidden; }
+.album-cover img { width: 100%; height: 100%; object-fit: cover; display: block; }
+.album-blank { display: grid; place-items: center; width: 100%; height: 100%; color: var(--faint); font-size: 30px; }
+.album-name { padding: 8px 12px 0; font-weight: 600; font-size: 13.5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.album-count { padding: 0 12px; color: var(--faint); }
+.album-title-row { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+.album-title { max-width: 300px; min-height: 38px; font-weight: 600; }
+.album-photo { cursor: pointer; }
+.album-remove { position: absolute; z-index: 2; top: 6px; right: 6px; width: 24px; height: 24px; padding: 0; display: grid; place-items: center; border-radius: 50%; border: none; background: rgba(0,0,0,.65); color: #fff; font-size: 14px; opacity: 0; transition: opacity .15s ease; }
+.album-photo:hover .album-remove { opacity: 1; }
+.album-remove:hover { background: var(--danger); }
+.suggest-thumb { position: relative; cursor: pointer; }
+.add-suggest { position: absolute; right: 3px; bottom: 3px; opacity: .92; }
+.album-add { position: relative; }
+.picker-panel.right { left: auto; right: 0; }
+.picker-panel.right .album-create { margin-top: 10px; }
+.score.text-hit { color: #ffd88a; background: rgba(58,42,8,.85); letter-spacing: .08em; }
+
 /* -- manage view -------------------------------------------------------------------------------------- */
 .roots-list { display: flex; flex-direction: column; gap: 8px; }
 .root-row { display: flex; align-items: center; justify-content: space-between; gap: 14px; padding: 12px 14px; border: 1px solid var(--line-soft); border-radius: var(--radius); background: var(--surface-2); }

--- a/desktop/ui/app.js
+++ b/desktop/ui/app.js
@@ -21,8 +21,12 @@ const state = {
   currentPerson: null,
   selectedFaces: new Set(),
   selectedModalFace: null,
+  modalImageId: null,
   forgetArmed: false,
   mergeArmedId: null,
+  albums: [],
+  currentAlbum: null,
+  albumDeleteArmed: false,
   loadCount: 0,
 };
 
@@ -309,14 +313,17 @@ async function findActiveJob() {
 
 function setView(view) {
   state.view = view;
-  for (const [id, name] of [["photosView", "photos"], ["peopleView", "people"], ["manageView", "manage"]]) {
+  for (const [id, name] of [["photosView", "photos"], ["peopleView", "people"],
+                            ["albumsView", "albums"], ["manageView", "manage"]]) {
     $(id).classList.toggle("hidden", view !== name);
   }
-  for (const [id, name] of [["tabPhotos", "photos"], ["tabPeople", "people"], ["tabManage", "manage"]]) {
+  for (const [id, name] of [["tabPhotos", "photos"], ["tabPeople", "people"],
+                            ["tabAlbums", "albums"], ["tabManage", "manage"]]) {
     $(id).classList.toggle("active", view === name);
     $(id).setAttribute("aria-selected", String(view === name));
   }
   if (view === "people") loadPeopleView();
+  if (view === "albums") loadAlbumsView();
   if (view === "manage") loadManageView();
 }
 
@@ -570,7 +577,8 @@ function renderPhotos(result) {
           <span>${escapeHtml(formatDate(photo.taken_at))}</span>
           <span>${photo.face_count ? `${photo.face_count}👤` : ""}</span>
         </span>
-        ${typeof photo.score === "number" ? `<span class="score mono" title="Match strength">${Math.round(photo.score * 100)}</span>` : ""}
+        ${photo.text_match ? '<span class="score mono text-hit" title="The query matched text inside this image">TEXT</span>'
+          : typeof photo.score === "number" ? `<span class="score mono" title="Match strength">${Math.round(photo.score * 100)}</span>` : ""}
       </button>
     `).join("");
     grid.querySelectorAll(".photo").forEach((button) => {
@@ -633,7 +641,10 @@ function renderTimeline() {
 
 async function openPhoto(imageId, filename = "") {
   state.modalIndex = state.results.findIndex((r) => r.image_id === Number(imageId));
+  state.modalImageId = Number(imageId);
   updateModalNav();
+  $("albumPickPanel").classList.add("hidden");
+  $("modalAlbumBtn").textContent = "Add to album";
   $("photoModal").classList.remove("hidden");
   $("modalImage").src = `${API}/images/${imageId}`;
   $("modalName").textContent = filename || "Loading…";
@@ -672,6 +683,8 @@ function renderExif(details) {
   add("file", details.file_size ? formatBytes(details.file_size) : "");
   add("folder", details.folder);
   add("place", details.place);
+  add("text", details.ocr_text
+    ? details.ocr_text.replaceAll("\n", " · ").slice(0, 300) : "");
   $("modalDetailsBtn").classList.toggle("hidden",
     !rows.length && details.lat == null);
   const hasGps = details.lat != null && details.lon != null;
@@ -928,10 +941,20 @@ function startInlineRename(tile, personId) {
   input.addEventListener("blur", () => finish(true));
 }
 
+function mergeReviewOpen() {
+  return localStorage.getItem("photolib.mergeOpen") === "1";
+}
+
+function applyMergeCollapse() {
+  const open = mergeReviewOpen();
+  $("mergeBody").classList.toggle("hidden", !open);
+  $("mergeToggle").setAttribute("aria-expanded", String(open));
+  $("mergeToggle").querySelector(".collapse-chevron").textContent = open ? "▾" : "▸";
+}
+
 async function loadMergeSuggestions() {
-  const panel = $("mergeSuggestPanel");
   const list = $("mergeSuggestList");
-  panel.classList.remove("hidden");
+  applyMergeCollapse();
   try {
     // A low floor keeps the section alive with long-shot candidates; the
     // similarity badge tells the user how seriously to take each one.
@@ -939,6 +962,8 @@ async function loadMergeSuggestions() {
     const dismissed = dismissedMerges();
     const pairs = (body.suggestions || []).filter(
       (s) => !dismissed.has(mergeKey(s.source.person_id, s.target.person_id)));
+    $("mergeCount").textContent = pairs.length
+      ? `${pairs.length} TO REVIEW` : "ALL CLEAR";
     if (!pairs.length) {
       list.innerHTML = '<div class="empty slim-empty">Nothing left to review — no two people look alike right now.</div>';
       return;
@@ -983,6 +1008,7 @@ async function loadMergeSuggestions() {
       });
     });
   } catch {
+    $("mergeCount").textContent = "";
     list.innerHTML = '<div class="empty slim-empty">Merge suggestions are unavailable right now.</div>';
   }
 }
@@ -1273,6 +1299,7 @@ async function detachSelectedFaces() {
 
 async function loadManageView() {
   loadRoots();
+  loadOcrStatus();
   refreshModels().catch(() => {});
 }
 
@@ -1399,6 +1426,331 @@ async function loadDupes() {
 }
 
 // ---------------------------------------------------------------------------
+// Albums
+// ---------------------------------------------------------------------------
+
+async function loadAlbums() {
+  try {
+    state.albums = (await request("/albums")).albums || [];
+  } catch {
+    state.albums = [];
+  }
+}
+
+async function loadAlbumsView() {
+  $("albumDetail").classList.add("hidden");
+  $("albumsHome").classList.remove("hidden");
+  startLoad();
+  try {
+    await loadAlbums();
+    renderAlbumsGrid();
+  } finally {
+    endLoad();
+  }
+}
+
+function albumCoverHtml(album) {
+  if (album.cover_image_id >= 0) {
+    return `<img loading="lazy" src="${API}/images/${album.cover_image_id}/thumbnail?size=grid&format=webp" alt="">`;
+  }
+  return '<span class="album-blank" aria-hidden="true">▦</span>';
+}
+
+function renderAlbumsGrid() {
+  const grid = $("albumsGrid");
+  if (!state.albums.length) {
+    grid.innerHTML = '<div class="empty">No albums yet. Name one above, then add photos from the viewer or the suggestions inside the album.</div>';
+    return;
+  }
+  grid.innerHTML = state.albums.map((album) => `
+    <button class="album-card" type="button" data-album-id="${album.album_id}">
+      <span class="album-cover">${albumCoverHtml(album)}</span>
+      <span class="album-name">${escapeHtml(album.name)}</span>
+      <span class="album-count mono">${album.photo_count} ${album.photo_count === 1 ? "PHOTO" : "PHOTOS"}</span>
+    </button>
+  `).join("");
+  grid.querySelectorAll(".album-card").forEach((card) => {
+    card.addEventListener("click", () => openAlbum(Number(card.dataset.albumId)));
+  });
+}
+
+async function createAlbum(name, imageIds = []) {
+  const album = await request("/albums", {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  });
+  if (imageIds.length) {
+    await request(`/albums/${album.album_id}/items`, {
+      method: "POST",
+      body: JSON.stringify({ image_ids: imageIds }),
+    });
+  }
+  await loadAlbums();
+  return album;
+}
+
+async function openAlbum(albumId) {
+  state.albumDeleteArmed = false;
+  $("albumDelete").textContent = "Delete album";
+  $("albumsHome").classList.add("hidden");
+  $("albumDetail").classList.remove("hidden");
+  $("albumPhotos").innerHTML = skeletonGrid(6);
+  $("albumSuggestions").innerHTML = "";
+  startLoad();
+  try {
+    const detail = await request(`/albums/${albumId}?limit=500`);
+    state.currentAlbum = detail;
+    $("albumTitle").value = detail.name;
+    $("albumMeta").textContent =
+      `${detail.photo_count} ${detail.photo_count === 1 ? "PHOTO" : "PHOTOS"}`;
+    renderAlbumPhotos(detail);
+    loadAlbumSuggestions(albumId);
+  } catch (error) {
+    showError(`Could not open the album: ${error.message}`);
+    loadAlbumsView();
+  } finally {
+    endLoad();
+  }
+}
+
+function renderAlbumPhotos(detail) {
+  const grid = $("albumPhotos");
+  $("albumPhotosTitle").textContent = `Photos (${detail.images.length})`;
+  if (!detail.images.length) {
+    grid.innerHTML = '<div class="empty">Empty so far. Add photos from the suggestions above, or from any photo\'s "Add to album" button.</div>';
+    return;
+  }
+  grid.innerHTML = detail.images.map((photo) => `
+    <div class="photo album-photo" data-image-id="${photo.image_id}">
+      <img loading="lazy" src="${API}/images/${photo.image_id}/thumbnail?size=grid&format=webp" alt="${escapeHtml(photo.filename || "Photo")}">
+      <button class="album-remove mono" type="button" data-remove="${photo.image_id}" title="Remove from album">×</button>
+    </div>
+  `).join("");
+  grid.querySelectorAll(".album-photo").forEach((tile) => {
+    tile.addEventListener("click", (event) => {
+      if (event.target.closest(".album-remove")) return;
+      openPhoto(Number(tile.dataset.imageId));
+    });
+  });
+  grid.querySelectorAll(".album-remove").forEach((button) => {
+    button.addEventListener("click", async () => {
+      const album = state.currentAlbum;
+      if (!album) return;
+      try {
+        await request(`/albums/${album.album_id}/items/remove`, {
+          method: "POST",
+          body: JSON.stringify({ image_ids: [Number(button.dataset.remove)] }),
+        });
+        openAlbum(album.album_id);
+      } catch (error) {
+        showError(`Could not remove the photo: ${error.message}`);
+      }
+    });
+  });
+}
+
+async function loadAlbumSuggestions(albumId) {
+  const row = $("albumSuggestions");
+  row.innerHTML = '<div class="empty slim-empty">Looking for photos that fit…</div>';
+  try {
+    const body = await request(`/albums/${albumId}/suggestions?limit=18`);
+    const suggestions = body.suggestions || [];
+    if (!suggestions.length) {
+      row.innerHTML = '<div class="empty slim-empty">Add a photo or two first — suggestions come from what the album already holds.</div>';
+      return;
+    }
+    row.innerHTML = suggestions.map((photo) => `
+      <div class="dupe-thumb suggest-thumb" data-image-id="${photo.image_id}">
+        <img loading="lazy" src="${API}/images/${photo.image_id}/thumbnail?size=grid&format=webp" alt="">
+        <button class="mini-btn yes add-suggest" type="button" data-add="${photo.image_id}" aria-label="Add to album">+</button>
+      </div>
+    `).join("");
+    row.querySelectorAll(".suggest-thumb").forEach((thumb) => {
+      thumb.addEventListener("click", (event) => {
+        if (event.target.closest(".add-suggest")) return;
+        openPhoto(Number(thumb.dataset.imageId));
+      });
+    });
+    row.querySelectorAll(".add-suggest").forEach((button) => {
+      button.addEventListener("click", async () => {
+        const album = state.currentAlbum;
+        if (!album) return;
+        button.disabled = true;
+        try {
+          await request(`/albums/${album.album_id}/items`, {
+            method: "POST",
+            body: JSON.stringify({ image_ids: [Number(button.dataset.add)] }),
+          });
+          openAlbum(album.album_id);
+        } catch (error) {
+          showError(`Could not add the photo: ${error.message}`);
+          button.disabled = false;
+        }
+      });
+    });
+  } catch {
+    row.innerHTML = "";
+  }
+}
+
+async function saveAlbumTitle() {
+  const album = state.currentAlbum;
+  if (!album) return;
+  const name = $("albumTitle").value.trim();
+  if (!name || name === album.name) return;
+  try {
+    await request(`/albums/${album.album_id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ name }),
+    });
+    album.name = name;
+    await loadAlbums();
+  } catch (error) {
+    showError(`Rename failed: ${error.message}`);
+  }
+}
+
+async function deleteAlbum() {
+  const album = state.currentAlbum;
+  if (!album) return;
+  if (!state.albumDeleteArmed) {
+    state.albumDeleteArmed = true;
+    $("albumDelete").textContent = "Really delete? Photos stay in the library";
+    return;
+  }
+  try {
+    await request(`/albums/${album.album_id}`, { method: "DELETE" });
+    state.currentAlbum = null;
+    loadAlbumsView();
+  } catch (error) {
+    showError(`Could not delete the album: ${error.message}`);
+  }
+}
+
+function toggleAlbumPicker() {
+  const panel = $("albumPickPanel");
+  const show = panel.classList.contains("hidden");
+  panel.classList.toggle("hidden", !show);
+  $("modalAlbumBtn").setAttribute("aria-expanded", String(show));
+  if (!show) return;
+  loadAlbums().then(() => {
+    $("albumPickList").innerHTML = state.albums.length
+      ? state.albums.map((album) => `
+          <button class="picker-row" type="button" data-album-id="${album.album_id}">
+            <span class="picker-name">${escapeHtml(album.name)}</span>
+            <span class="picker-count mono">${album.photo_count}</span>
+          </button>`).join("")
+      : '<div class="empty slim-empty">No albums yet — create one below.</div>';
+    $("albumPickList").querySelectorAll(".picker-row").forEach((rowEl) => {
+      rowEl.addEventListener("click", () =>
+        addCurrentPhotoToAlbum(Number(rowEl.dataset.albumId)));
+    });
+  });
+}
+
+async function addCurrentPhotoToAlbum(albumId) {
+  if (state.modalImageId == null) return;
+  try {
+    await request(`/albums/${albumId}/items`, {
+      method: "POST",
+      body: JSON.stringify({ image_ids: [state.modalImageId] }),
+    });
+    $("albumPickPanel").classList.add("hidden");
+    $("modalAlbumBtn").textContent = "Added ✓";
+    setTimeout(() => { $("modalAlbumBtn").textContent = "Add to album"; }, 1500);
+  } catch (error) {
+    showError(`Could not add to the album: ${error.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Paste an image to search
+// ---------------------------------------------------------------------------
+
+async function searchByImageFile(file) {
+  clearError();
+  setView("photos");
+  $("photoGrid").innerHTML = skeletonGrid();
+  startLoad();
+  try {
+    const form = new FormData();
+    form.append("file", file, file.name || "pasted.png");
+    form.append("per_page", String(state.perPage));
+    const response = await fetch(`${API}/search/by-image`, {
+      method: "POST",
+      body: form,
+    });
+    const body = await response.json();
+    if (!response.ok) {
+      throw new Error(body.detail || `Search failed (${response.status})`);
+    }
+    state.similarTo = { pasted: true };
+    $("similarText").textContent = "Results for the image you pasted.";
+    $("similarBanner").classList.remove("hidden");
+    renderPhotos(body);
+    $("resultCount").textContent =
+      `${body.total.toLocaleString()} MATCHES · PASTED IMAGE`;
+    $("pager").classList.add("hidden");
+  } catch (error) {
+    $("photoGrid").innerHTML = "";
+    showError(`Image search failed: ${error.message}`);
+  } finally {
+    endLoad();
+  }
+}
+
+function handlePaste(event) {
+  const items = event.clipboardData?.items || [];
+  for (const item of items) {
+    if (item.kind === "file" && item.type.startsWith("image/")) {
+      const file = item.getAsFile();
+      if (file) {
+        event.preventDefault();
+        searchByImageFile(file);
+      }
+      return;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// OCR status (Library tab)
+// ---------------------------------------------------------------------------
+
+async function loadOcrStatus() {
+  try {
+    const status = await request("/admin/ocr");
+    const line = $("ocrStatusLine");
+    if (!status.available) {
+      $("ocrScan").disabled = true;
+      $("ocrCopy").textContent =
+        "The OCR engine is not installed in this build, so text inside photos cannot be read yet.";
+      line.innerHTML = "";
+      return;
+    }
+    $("ocrScan").disabled = Boolean(state.activeJob);
+    const remaining = Math.max(0, status.total_images - status.scanned);
+    $("ocrScan").textContent = remaining ? "Scan photo text" : "Rescan (up to date)";
+    line.innerHTML = `<div class="model-line"><span>coverage</span>` +
+      `<span>${status.scanned.toLocaleString()} of ${status.total_images.toLocaleString()} scanned` +
+      ` · ${status.with_text.toLocaleString()} with text</span></div>`;
+  } catch {
+    $("ocrStatusLine").innerHTML = "";
+  }
+}
+
+async function startOcrScan() {
+  clearError();
+  try {
+    const job = await request("/admin/ocr", { method: "POST" });
+    await monitorJob(job);
+    loadOcrStatus();
+  } catch (error) {
+    showError(`Could not scan for text: ${error.message}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Stats and startup
 // ---------------------------------------------------------------------------
 
@@ -1461,7 +1813,50 @@ async function init() {
 
   $("tabPhotos").addEventListener("click", () => setView("photos"));
   $("tabPeople").addEventListener("click", () => setView("people"));
+  $("tabAlbums").addEventListener("click", () => setView("albums"));
   $("tabManage").addEventListener("click", () => setView("manage"));
+
+  $("mergeToggle").addEventListener("click", () => {
+    localStorage.setItem("photolib.mergeOpen", mergeReviewOpen() ? "0" : "1");
+    applyMergeCollapse();
+  });
+
+  $("albumCreateForm").addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const name = $("albumName").value.trim();
+    if (!name) return;
+    try {
+      const album = await createAlbum(name);
+      $("albumName").value = "";
+      openAlbum(album.album_id);
+    } catch (error) {
+      showError(`Could not create the album: ${error.message}`);
+    }
+  });
+  $("albumBack").addEventListener("click", loadAlbumsView);
+  $("albumTitle").addEventListener("blur", saveAlbumTitle);
+  $("albumTitle").addEventListener("keydown", (event) => {
+    if (event.key === "Enter") saveAlbumTitle();
+  });
+  $("albumDelete").addEventListener("click", deleteAlbum);
+  $("modalAlbumBtn").addEventListener("click", toggleAlbumPicker);
+  $("albumPickCreate").addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const name = $("albumPickName").value.trim();
+    if (!name || state.modalImageId == null) return;
+    try {
+      await createAlbum(name, [state.modalImageId]);
+      $("albumPickName").value = "";
+      $("albumPickPanel").classList.add("hidden");
+      $("modalAlbumBtn").textContent = "Added ✓";
+      setTimeout(() => { $("modalAlbumBtn").textContent = "Add to album"; }, 1500);
+    } catch (error) {
+      showError(`Could not create the album: ${error.message}`);
+    }
+  });
+
+  $("ocrScan").addEventListener("click", startOcrScan);
+  document.addEventListener("paste", handlePaste);
 
   $("searchForm").addEventListener("submit", (event) => {
     event.preventDefault();
@@ -1545,6 +1940,12 @@ async function init() {
     }
     if (photoOpen && event.key === "ArrowRight") navigatePhoto(1);
     if (photoOpen && event.key === "ArrowLeft") navigatePhoto(-1);
+    if (event.key === "/" && !photoOpen
+        && !["INPUT", "TEXTAREA", "SELECT"].includes(event.target.tagName)) {
+      event.preventDefault();
+      setView("photos");
+      $("searchInput").focus();
+    }
   });
 
   try {

--- a/desktop/ui/index.html
+++ b/desktop/ui/index.html
@@ -65,6 +65,7 @@
         <nav class="tabs" role="tablist" aria-label="Library views">
           <button id="tabPhotos" class="tab active" type="button" role="tab" aria-selected="true">Photos</button>
           <button id="tabPeople" class="tab" type="button" role="tab" aria-selected="false">People</button>
+          <button id="tabAlbums" class="tab" type="button" role="tab" aria-selected="false">Albums</button>
           <button id="tabManage" class="tab" type="button" role="tab" aria-selected="false">Library</button>
           <span id="resultCount" class="tabs-meta mono"></span>
         </nav>
@@ -126,10 +127,15 @@
 
         <div id="peopleView" class="hidden">
           <section id="mergeSuggestPanel" class="panel">
-            <div class="panel-head">
-              <div><h2>Merge review</h2><p>Likeliest pairs first, long shots included. Merging keeps every photo — and future scans recognise the merged person. Tip: click a person's name below to rename them right there.</p></div>
+            <button id="mergeToggle" class="collapse-head" type="button" aria-expanded="false">
+              <span class="collapse-chevron" aria-hidden="true">▸</span>
+              <h2>Merge review</h2>
+              <span id="mergeCount" class="mono collapse-count"></span>
+            </button>
+            <div id="mergeBody" class="hidden">
+              <p class="collapse-copy">Likeliest pairs first, long shots included. Merging keeps every photo — and future scans recognise the merged person. Tip: click a person's name below to rename them right there.</p>
+              <div id="mergeSuggestList" class="merge-cards"></div>
             </div>
-            <div id="mergeSuggestList" class="merge-cards"></div>
           </section>
           <section id="untaggedPanel" class="panel hidden">
             <div class="panel-head">
@@ -139,6 +145,50 @@
             <div id="untaggedRow" class="thumb-row"></div>
           </section>
           <div id="peopleGrid" class="people-grid"></div>
+        </div>
+
+        <div id="albumsView" class="hidden">
+          <div id="albumsHome">
+            <section class="panel">
+              <div class="panel-head">
+                <div><h2>Albums</h2><p>Collections you curate. Each album also suggests lookalike photos so filling it takes seconds.</p></div>
+                <form id="albumCreateForm" class="album-create">
+                  <input id="albumName" class="field slim" type="text" maxlength="200" placeholder="New album name…" aria-label="New album name">
+                  <button class="btn primary" type="submit">Create</button>
+                </form>
+              </div>
+              <div id="albumsGrid" class="albums-grid"></div>
+            </section>
+          </div>
+
+          <div id="albumDetail" class="hidden">
+            <section class="panel">
+              <div class="panel-head">
+                <div class="album-title-row">
+                  <button id="albumBack" class="btn ghost" type="button">← Albums</button>
+                  <input id="albumTitle" class="field album-title" type="text" maxlength="200" aria-label="Album name">
+                  <span id="albumMeta" class="mono"></span>
+                </div>
+                <button id="albumDelete" class="btn ghost danger" type="button">Delete album</button>
+              </div>
+
+              <div class="person-section">
+                <div class="section-head">
+                  <h4>Looks like it belongs</h4>
+                  <span class="section-hint mono">+ adds the photo to this album</span>
+                </div>
+                <div id="albumSuggestions" class="thumb-row"></div>
+              </div>
+
+              <div class="person-section">
+                <div class="section-head">
+                  <h4 id="albumPhotosTitle">Photos</h4>
+                  <span class="section-hint mono">hover a photo for remove · click to open</span>
+                </div>
+                <div id="albumPhotos" class="grid"></div>
+              </div>
+            </section>
+          </div>
         </div>
 
         <div id="manageView" class="hidden">
@@ -155,6 +205,14 @@
               <input id="pruneMissing" type="checkbox">
               During rescans, remove entries whose original files no longer exist
             </label>
+          </section>
+
+          <section class="panel">
+            <div class="panel-head">
+              <div><h2>Text in photos</h2><p id="ocrCopy">Read the text inside screenshots and documents so searches match it exactly. Runs once per photo, entirely on this machine.</p></div>
+              <button id="ocrScan" class="btn primary" type="button">Scan photo text</button>
+            </div>
+            <div id="ocrStatusLine" class="mono model-lines"></div>
           </section>
 
           <section class="panel">
@@ -190,6 +248,16 @@
         <div class="modal-buttons">
           <button id="modalDetailsBtn" class="btn ghost" type="button">Details</button>
           <button id="modalSimilar" class="btn ghost" type="button">More like this</button>
+          <div class="album-add">
+            <button id="modalAlbumBtn" class="btn ghost" type="button" aria-haspopup="true" aria-expanded="false">Add to album</button>
+            <div id="albumPickPanel" class="picker-panel right hidden">
+              <div id="albumPickList" class="picker-list"></div>
+              <form id="albumPickCreate" class="album-create">
+                <input id="albumPickName" class="field slim" type="text" maxlength="200" placeholder="New album…" aria-label="New album name">
+                <button class="btn slim-btn" type="submit">Create &amp; add</button>
+              </form>
+            </div>
+          </div>
         </div>
       </div>
       <div id="modalExif" class="exif hidden"></div>

--- a/docs/superpowers/specs/2026-07-26-ocr-albums-design.md
+++ b/docs/superpowers/specs/2026-07-26-ocr-albums-design.md
@@ -1,0 +1,65 @@
+# Local OCR, albums, and paste-to-search — design
+
+Date: 2026-07-26 · Branch: feature/local-ocr (PR #7)
+
+## Why OCR
+
+The library is screenshot-heavy, and queries like "JROTC" are literal
+strings rendered inside images. The 224px embedding model cannot read fine
+print, so semantic ranking underperforms exactly where OpenAI CLIP
+(accidentally good at typography) used to shine. OCR closes the gap with
+exact text matching.
+
+## Engine
+
+Two backends behind one interface (`photolib/ocr.py`), chosen by
+`PHOTO_OCR_BACKEND=auto`:
+
+1. **Windows.Media.Ocr** (via winsdk) — ships with Windows, no model
+   download, benchmarked at ~0.25s per dense 2,544px screenshot.
+2. **RapidOCR** (PaddleOCR on onnxruntime) — cross-platform fallback,
+   models inside the wheel, ~5–8s per dense screenshot on CPU.
+
+Both are strictly offline. Neither is required: without them the app
+behaves exactly as before. A `stub` backend (filename words) keeps CI
+model-free.
+
+## Storage: no reindex, ever
+
+Text lives in a new lazily-created `ocr` table (image_id, text, engine,
+updated_at) — adding OCR to an existing library is an append, not a schema
+migration. A row exists for every *scanned* image even when empty, which is
+what lets the backfill know what remains.
+
+- **Index time**: the indexer reuses the already-decoded pixel buffer
+  (decode-once holds) and writes OCR rows alongside image rows.
+- **Backfill** (`POST /admin/ocr`): scans only never-scanned images, newest
+  first, in a cancellable, resumable background job. The images table is
+  never rewritten (regression-tested via table version).
+
+## Search
+
+Hybrid ranking in `PhotoService.search`: photos whose text contains every
+query token rank ahead of semantic matches (marked `text_match`, shown as a
+TEXT badge). Date sorts merge both sets. The browse index holds lowercase
+text in memory (~KBs per screenshot; empty for ordinary photos) and tracks
+the OCR table version for freshness.
+
+## Albums
+
+`albums` + `album_items` tables (lazy). CRUD under `/albums`; the album's
+"looks like it belongs" strip ranks non-members against the mean embedding
+of the newest 32 members — one-click add. UI: Albums tab (create, inline
+rename, two-step delete, hover-remove) and an "Add to album" picker (with
+create-new) in the photo viewer.
+
+## QoL
+
+- Ctrl+V an image anywhere → `/search/by-image` on the pasted bytes.
+- Merge review collapsed by default with a count badge; state remembered.
+- `/` focuses search.
+
+## Out of scope
+
+Tantivy/FTS indexing (in-memory substring is fine below ~200k screenshots),
+OCR language packs beyond the user profile's, translation.

--- a/packaging/photolib.spec
+++ b/packaging/photolib.spec
@@ -38,6 +38,15 @@ else:
 binaries = collect_dynamic_libs("onnxruntime") + collect_dynamic_libs("lance")
 datas += collect_data_files("onnxruntime")
 
+# RapidOCR keeps its detection/recognition models and config inside the
+# package; collect them so text-in-photos search works when frozen. The
+# try/except keeps the spec usable in a build without OCR.
+try:
+    datas += collect_data_files("rapidocr_onnxruntime")
+except Exception as exc:
+    print(f"WARNING: rapidocr not bundled ({exc}); "
+          "text-in-photos search will be unavailable", file=sys.stderr)
+
 hiddenimports = [
     "uvicorn.logging",
     "uvicorn.loops.auto",
@@ -48,6 +57,7 @@ hiddenimports = [
     "photolib.faces.insight",
     "pillow_heif",
     "tokenizers",
+    "rapidocr_onnxruntime",
 ]
 
 # Nothing here uses PyTorch — the ONNX backend is the entire point. Excluding

--- a/packaging/photolib.spec
+++ b/packaging/photolib.spec
@@ -58,6 +58,10 @@ hiddenimports = [
     "pillow_heif",
     "tokenizers",
     "rapidocr_onnxruntime",
+    # Native Windows OCR projection modules (loaded dynamically).
+    "winsdk.windows.media.ocr",
+    "winsdk.windows.graphics.imaging",
+    "winsdk.windows.storage.streams",
 ]
 
 # Nothing here uses PyTorch — the ONNX backend is the entire point. Excluding

--- a/photolib/api/app.py
+++ b/photolib/api/app.py
@@ -16,7 +16,7 @@ from .. import __version__
 from ..config import Settings, get_settings
 from ..webui import mount_web_ui
 from .deps import get_service
-from .routers import admin, faces, images, people, search
+from .routers import admin, albums, faces, images, people, search
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +102,7 @@ def create_app(settings: Settings | None = None,
                             content={"detail": "Internal server error"})
 
     for router in (search.router, images.router, people.router,
-                   faces.router, admin.router):
+                   faces.router, albums.router, admin.router):
         app.include_router(router, prefix=API_PREFIX)
 
     @app.get("/api")

--- a/photolib/api/routers/admin.py
+++ b/photolib/api/routers/admin.py
@@ -168,6 +168,31 @@ def fetch_models(service: PhotoService = Depends(get_service)):
     return JobOut(**job.to_dict())
 
 
+@router.post("/admin/ocr", response_model=JobOut)
+def start_ocr(service: PhotoService = Depends(get_service)):
+    """Extract text from every not-yet-scanned photo, as a background job.
+
+    Incremental: photos already scanned are skipped, so cancelling and
+    re-running resumes where it stopped. Nothing is re-embedded.
+    """
+    try:
+        job = service.start_ocr_backfill_job()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+    except Exception as exc:
+        raise translate_errors(exc)
+    return JobOut(**job.to_dict())
+
+
+@router.get("/admin/ocr")
+def ocr_status(service: PhotoService = Depends(get_service)):
+    """Text-recognition availability and coverage."""
+    try:
+        return service.ocr_status()
+    except Exception as exc:
+        raise translate_errors(exc)
+
+
 @router.get("/admin/duplicates")
 def duplicates(max_distance: int = Query(6, ge=0, le=20),
                limit: int = Query(200, ge=1, le=1000),

--- a/photolib/api/routers/albums.py
+++ b/photolib/api/routers/albums.py
@@ -1,0 +1,87 @@
+"""Albums: user-curated collections with similarity-powered suggestions."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Body, Depends, Query
+
+from ...service import PhotoService
+from ..deps import get_service, translate_errors
+from ..schemas import AlbumCreateRequest, AlbumItemsRequest, AlbumRenameRequest
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/albums", tags=["albums"])
+
+
+@router.get("")
+def list_albums(service: PhotoService = Depends(get_service)):
+    try:
+        return {"albums": service.list_albums()}
+    except Exception as exc:
+        raise translate_errors(exc)
+
+
+@router.post("")
+def create_album(req: AlbumCreateRequest,
+                 service: PhotoService = Depends(get_service)):
+    try:
+        return service.create_album(req.name)
+    except Exception as exc:
+        raise translate_errors(exc)
+
+
+@router.get("/{album_id}")
+def album_detail(album_id: int, limit: int = Query(500, ge=1, le=2000),
+                 service: PhotoService = Depends(get_service)):
+    """The album plus its photos, newest addition first."""
+    try:
+        return service.album_detail(album_id, limit)
+    except Exception as exc:
+        raise translate_errors(exc)
+
+
+@router.patch("/{album_id}")
+def rename_album(album_id: int, req: AlbumRenameRequest = Body(...),
+                 service: PhotoService = Depends(get_service)):
+    try:
+        return service.rename_album(album_id, req.name)
+    except Exception as exc:
+        raise translate_errors(exc)
+
+
+@router.delete("/{album_id}")
+def delete_album(album_id: int, service: PhotoService = Depends(get_service)):
+    """Delete the album. The photos in it are untouched."""
+    try:
+        return service.delete_album(album_id)
+    except Exception as exc:
+        raise translate_errors(exc)
+
+
+@router.post("/{album_id}/items")
+def add_items(album_id: int, req: AlbumItemsRequest,
+              service: PhotoService = Depends(get_service)):
+    try:
+        return service.add_album_items(album_id, req.image_ids)
+    except Exception as exc:
+        raise translate_errors(exc)
+
+
+@router.post("/{album_id}/items/remove")
+def remove_items(album_id: int, req: AlbumItemsRequest,
+                 service: PhotoService = Depends(get_service)):
+    try:
+        return service.remove_album_items(album_id, req.image_ids)
+    except Exception as exc:
+        raise translate_errors(exc)
+
+
+@router.get("/{album_id}/suggestions")
+def suggestions(album_id: int, limit: int = Query(24, ge=1, le=100),
+                service: PhotoService = Depends(get_service)):
+    """Photos that look like this album, for one-click adding."""
+    try:
+        return {"suggestions": service.album_suggestions(album_id, limit)}
+    except Exception as exc:
+        raise translate_errors(exc)

--- a/photolib/api/schemas.py
+++ b/photolib/api/schemas.py
@@ -52,6 +52,8 @@ class ImageSummary(BaseModel):
     width: int = 0
     height: int = 0
     score: Optional[float] = None
+    # True when the query matched text found in the image (OCR).
+    text_match: Optional[bool] = None
 
 
 class SearchResponse(BaseModel):
@@ -123,6 +125,18 @@ class IndexRequest(BaseModel):
 
 class RootRequest(BaseModel):
     folder: str = Field(..., description="Absolute path to a photo folder")
+
+
+class AlbumCreateRequest(BaseModel):
+    name: str = Field(..., max_length=200)
+
+
+class AlbumRenameRequest(BaseModel):
+    name: str = Field(..., max_length=200)
+
+
+class AlbumItemsRequest(BaseModel):
+    image_ids: List[int] = Field(..., min_length=1)
 
 
 class ReclusterRequest(BaseModel):

--- a/photolib/browse.py
+++ b/photolib/browse.py
@@ -22,7 +22,7 @@ from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 
 import numpy as np
 
-from .db import Library
+from .db import Library, OCR
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +63,7 @@ class LibraryIndex:
         self._library = library
         self._lock = threading.RLock()
         self._version: Optional[int] = None
+        self._ocr_version: Optional[int] = None
         self._built = False
 
         self.image_ids = np.zeros(0, dtype=np.int64)
@@ -73,6 +74,8 @@ class LibraryIndex:
         self.face_count = np.zeros(0, dtype=np.int32)
         self.folders: List[str] = []
         self.cameras: List[str] = []
+        self.ocr_text: List[str] = []          # lowercase; "" = none/unscanned
+        self.ocr_scanned = np.zeros(0, dtype=bool)
         self._row_of_id: Dict[int, int] = {}
         self._rows_by_person: Dict[int, np.ndarray] = {}
         self._person_counts: Dict[int, int] = {}
@@ -85,9 +88,20 @@ class LibraryIndex:
                 version = self._library.images.version
             except Exception:
                 version = None
-            if self._built and version == self._version:
+            ocr_version = self._ocr_table_version()
+            if (self._built and version == self._version
+                    and ocr_version == self._ocr_version):
                 return
             self._rebuild(version)
+            self._ocr_version = ocr_version
+
+    def _ocr_table_version(self) -> Optional[int]:
+        try:
+            if self._library.has_ocr():
+                return self._library.ocr.version
+        except Exception:
+            pass
+        return None
 
     def invalidate(self) -> None:
         with self._lock:
@@ -122,6 +136,8 @@ class LibraryIndex:
                                 for k, v in by_person.items()}
         self._person_counts = {k: len(v) for k, v in by_person.items()}
 
+        self._load_ocr(n)
+
         # Undated photos sort last rather than to 1970, which is where a
         # missing EXIF timestamp used to put them.
         keys = np.where(np.isnan(self.taken_ts), -np.inf, self.taken_ts)
@@ -129,6 +145,41 @@ class LibraryIndex:
 
         self._version = version
         self._built = True
+
+    def _load_ocr(self, n: int) -> None:
+        """Attach extracted text to image rows. Absent table = no text."""
+        self.ocr_text = [""] * n
+        self.ocr_scanned = np.zeros(n, dtype=bool)
+        try:
+            if not self._library.has_ocr():
+                return
+            table = self._library.ocr.to_lance().to_table(
+                columns=["image_id", "text"])
+        except Exception as exc:
+            logger.debug("OCR text not loaded: %s", exc)
+            return
+        for image_id, text in zip(table["image_id"].to_pylist(),
+                                  table["text"].to_pylist()):
+            row = self._row_of_id.get(int(image_id))
+            if row is None:
+                continue
+            self.ocr_scanned[row] = True
+            if text:
+                self.ocr_text[row] = str(text).lower()
+
+    def text_match(self, tokens: Sequence[str],
+                   allowed: Optional[np.ndarray] = None) -> np.ndarray:
+        """Rows whose extracted text contains every token (case-insensitive)."""
+        self.ensure_fresh()
+        if not tokens:
+            return np.zeros(0, dtype=np.int64)
+        wanted = [t.lower() for t in tokens if t]
+        rows = (range(len(self.ocr_text)) if allowed is None
+                else (int(r) for r in allowed))
+        hits = [row for row in rows
+                if self.ocr_text[row]
+                and all(t in self.ocr_text[row] for t in wanted)]
+        return np.asarray(hits, dtype=np.int64)
 
     # -- accessors -------------------------------------------------------
     @property

--- a/photolib/browse.py
+++ b/photolib/browse.py
@@ -63,6 +63,7 @@ class LibraryIndex:
         self._library = library
         self._lock = threading.RLock()
         self._version: Optional[int] = None
+        self._ocr_handle = None
         self._ocr_version: Optional[int] = None
         self._built = False
 
@@ -88,20 +89,24 @@ class LibraryIndex:
                 version = self._library.images.version
             except Exception:
                 version = None
-            ocr_version = self._ocr_table_version()
-            if (self._built and version == self._version
-                    and ocr_version == self._ocr_version):
+            if self._built and version == self._version and self._ocr_fresh():
                 return
             self._rebuild(version)
-            self._ocr_version = ocr_version
 
-    def _ocr_table_version(self) -> Optional[int]:
+    def _ocr_fresh(self) -> bool:
+        """Is the cached OCR text still current?
+
+        Uses the table handle captured at rebuild time — ensure_fresh runs on
+        every row lookup, so this must never touch the filesystem the way
+        ``table_names()``/``open_table()`` do. A brand-new OCR table is
+        picked up via ``invalidate()``, which every writer already calls.
+        """
+        if self._ocr_handle is None:
+            return True
         try:
-            if self._library.has_ocr():
-                return self._library.ocr.version
+            return self._ocr_handle.version == self._ocr_version
         except Exception:
-            pass
-        return None
+            return False
 
     def invalidate(self) -> None:
         with self._lock:
@@ -150,10 +155,14 @@ class LibraryIndex:
         """Attach extracted text to image rows. Absent table = no text."""
         self.ocr_text = [""] * n
         self.ocr_scanned = np.zeros(n, dtype=bool)
+        self._ocr_handle = None
+        self._ocr_version = None
         try:
             if not self._library.has_ocr():
                 return
-            table = self._library.ocr.to_lance().to_table(
+            self._ocr_handle = self._library.ocr
+            self._ocr_version = self._ocr_handle.version
+            table = self._ocr_handle.to_lance().to_table(
                 columns=["image_id", "text"])
         except Exception as exc:
             logger.debug("OCR text not loaded: %s", exc)
@@ -194,6 +203,15 @@ class LibraryIndex:
     def row_of(self, image_id: int) -> Optional[int]:
         self.ensure_fresh()
         return self._row_of_id.get(int(image_id))
+
+    def row_map(self) -> Dict[int, int]:
+        """image_id -> row, freshness checked once — for per-hit loops.
+
+        Calling ``row_of`` inside a 1000-hit loop pays the freshness check
+        1000 times; snapshotting the mapping pays it once.
+        """
+        self.ensure_fresh()
+        return self._row_of_id
 
     def ids_of(self, rows: np.ndarray) -> List[int]:
         return [int(v) for v in self.image_ids[rows]]

--- a/photolib/config.py
+++ b/photolib/config.py
@@ -53,7 +53,7 @@ class Settings(BaseSettings):
     # when the package is installed and silently skips OCR otherwise, so a
     # minimal install keeps working. Extracted text is stored once per image
     # and searched exactly, ahead of the semantic ranking.
-    ocr_backend: Literal["auto", "rapidocr", "stub", "off"] = "auto"
+    ocr_backend: Literal["auto", "windows", "rapidocr", "stub", "off"] = "auto"
     ocr_min_confidence: float = Field(0.5, ge=0.0, le=1.0)
     ocr_max_chars: int = Field(4000, ge=100, le=100_000)
     ocr_max_side: int = Field(1280, ge=320, le=4096,

--- a/photolib/config.py
+++ b/photolib/config.py
@@ -48,6 +48,17 @@ class Settings(BaseSettings):
     # float16 on GPU roughly halves memory and speeds up indexing; ignored on CPU.
     embed_fp16: bool = True
 
+    # ---- OCR ------------------------------------------------------------
+    # Text recognition for screenshots and documents. "auto" uses RapidOCR
+    # when the package is installed and silently skips OCR otherwise, so a
+    # minimal install keeps working. Extracted text is stored once per image
+    # and searched exactly, ahead of the semantic ranking.
+    ocr_backend: Literal["auto", "rapidocr", "stub", "off"] = "auto"
+    ocr_min_confidence: float = Field(0.5, ge=0.0, le=1.0)
+    ocr_max_chars: int = Field(4000, ge=100, le=100_000)
+    ocr_max_side: int = Field(1280, ge=320, le=4096,
+                              description="Long edge for OCR; smaller is faster")
+
     # ---- face model ----------------------------------------------------
     # InsightFace buffalo_l = RetinaFace detection + ArcFace w600k_r50
     # recognition. Substantially more accurate than dlib/face_recognition,

--- a/photolib/db.py
+++ b/photolib/db.py
@@ -30,6 +30,13 @@ IMAGES = "images"
 FACES = "faces"
 PEOPLE = "people"
 META = "meta"
+# Extracted text, one row per scanned image. A separate table rather than an
+# images column so that adding OCR to an existing library is an append, not
+# a schema migration — no re-embedding, no version bump.
+OCR = "ocr"
+# User-curated collections. Also created lazily, for the same reason.
+ALBUMS = "albums"
+ALBUM_ITEMS = "album_items"
 
 UNASSIGNED = -1  # person_id for a face that belongs to no person yet
 
@@ -106,6 +113,28 @@ META_SCHEMA = pa.schema([
     pa.field("value", pa.string()),
 ])
 
+# A row exists for every image that has been *scanned*, even when no text
+# was found — that is what lets a backfill know what is left to do.
+OCR_SCHEMA = pa.schema([
+    pa.field("image_id", pa.int64(), nullable=False),
+    pa.field("text", pa.string()),
+    pa.field("engine", pa.string()),
+    pa.field("updated_at", pa.timestamp("ms")),
+])
+
+ALBUMS_SCHEMA = pa.schema([
+    pa.field("album_id", pa.int32(), nullable=False),
+    pa.field("name", pa.string()),
+    pa.field("created_at", pa.timestamp("ms")),
+    pa.field("cover_image_id", pa.int64()),
+])
+
+ALBUM_ITEMS_SCHEMA = pa.schema([
+    pa.field("album_id", pa.int32(), nullable=False),
+    pa.field("image_id", pa.int64(), nullable=False),
+    pa.field("added_at", pa.timestamp("ms")),
+])
+
 
 @dataclass(frozen=True)
 class LibraryMeta:
@@ -163,6 +192,39 @@ class Library:
     @property
     def people(self):
         return self._db.open_table(PEOPLE)
+
+    @property
+    def ocr(self):
+        return self._db.open_table(OCR)
+
+    def has_ocr(self) -> bool:
+        return OCR in self.table_names()
+
+    def ensure_ocr(self):
+        """Create the OCR table on first use — old libraries gain it in place."""
+        with self._lock:
+            if OCR not in self.table_names():
+                self._db.create_table(OCR, schema=OCR_SCHEMA)
+        return self._db.open_table(OCR)
+
+    @property
+    def albums(self):
+        return self._db.open_table(ALBUMS)
+
+    @property
+    def album_items(self):
+        return self._db.open_table(ALBUM_ITEMS)
+
+    def has_albums(self) -> bool:
+        return ALBUMS in self.table_names()
+
+    def ensure_albums(self) -> None:
+        with self._lock:
+            names = set(self.table_names())
+            if ALBUMS not in names:
+                self._db.create_table(ALBUMS, schema=ALBUMS_SCHEMA)
+            if ALBUM_ITEMS not in names:
+                self._db.create_table(ALBUM_ITEMS, schema=ALBUM_ITEMS_SCHEMA)
 
     def initialised(self) -> bool:
         names = set(self.table_names())
@@ -318,7 +380,9 @@ class Library:
         library that has been updated a few hundred times reads far more
         files than it needs to.
         """
-        for name in (IMAGES, FACES, PEOPLE):
+        for name in (IMAGES, FACES, PEOPLE, OCR):
+            if name == OCR and not self.has_ocr():
+                continue
             try:
                 ds = self._db.open_table(name).to_lance()
                 ds.optimize.compact_files()

--- a/photolib/indexer.py
+++ b/photolib/indexer.py
@@ -36,6 +36,7 @@ from .faces import FaceBackend, build_face_backend
 from .faces.cluster import FaceAssigner, FaceObservation
 from .hashing import content_hash, phash
 from .imageio import iter_image_files, load_rgb_array, open_image
+from .ocr import build_ocr
 from .thumbnails import ThumbnailCache
 
 logger = logging.getLogger(__name__)
@@ -102,6 +103,11 @@ class Indexer:
         self.faces = face_backend or build_face_backend(self.settings)
         self.thumbs = thumbnails or ThumbnailCache(self.settings.thumbnail_cache_dir)
         self.progress = progress or (lambda *a, **k: None)
+        try:
+            self.ocr = build_ocr(self.settings)
+        except Exception as exc:  # a broken OCR install must not stop indexing
+            logger.warning("OCR disabled for this run: %s", exc)
+            self.ocr = None
 
     # -- public API ------------------------------------------------------
     def meta(self) -> LibraryMeta:
@@ -203,6 +209,8 @@ class Indexer:
             ids = ", ".join(str(int(i)) for i in chunk)
             self.library.images.delete(f"image_id IN ({ids})")
             self.library.faces.delete(f"image_id IN ({ids})")
+            if self.library.has_ocr():
+                self.library.ocr.delete(f"image_id IN ({ids})")
         for image_id in image_ids:
             try:
                 self.thumbs.purge_image(int(image_id))
@@ -240,6 +248,9 @@ class Indexer:
         workers = max(1, min(self.settings.worker_count, 16))
         image_rows: List[dict] = []
         face_rows: List[dict] = []
+        ocr_rows: List[dict] = []
+        if self.ocr is not None:
+            self.library.ensure_ocr()
         done = 0
 
         with ThreadPoolExecutor(max_workers=workers) as pool:
@@ -288,6 +299,19 @@ class Indexer:
                             image_id, prep, vector, people_ids, len(observations)))
                         face_rows.extend(self._face_row(o) for o in observations)
 
+                        if self.ocr is not None:
+                            # Reuse the already-decoded buffer: OCR is one
+                            # more consumer of the single decode.
+                            try:
+                                text = self.ocr.extract(prep.array, prep.path)
+                            except Exception as exc:
+                                logger.debug("OCR failed for %s: %s", prep.path, exc)
+                                text = ""
+                            ocr_rows.append({
+                                "image_id": image_id, "text": text,
+                                "engine": self.ocr.name, "updated_at": now_ms(),
+                            })
+
                     if self.settings.pregenerate_thumbnails:
                         pool.map(self._pregenerate,
                                  [(r["image_id"], r["path"]) for r in image_rows[-len(good):]])
@@ -302,13 +326,14 @@ class Indexer:
                                "faces": stats.faces_detected})
 
                 if len(image_rows) >= self.settings.write_batch_size:
-                    self._write(image_rows, face_rows, img_schema, face_schema)
+                    self._write(image_rows, face_rows, img_schema, face_schema,
+                                ocr_rows)
                     stats.added += len(image_rows)
-                    image_rows, face_rows = [], []
+                    image_rows, face_rows, ocr_rows = [], [], []
                     assigner.flush()
 
         if image_rows:
-            self._write(image_rows, face_rows, img_schema, face_schema)
+            self._write(image_rows, face_rows, img_schema, face_schema, ocr_rows)
             stats.added += len(image_rows)
         assigner.flush()
         stats.people_created = max(0, len(assigner.people) - people_before)
@@ -443,11 +468,16 @@ class Indexer:
         self.thumbs.pregenerate(image_id, path)
 
     def _write(self, image_rows: List[dict], face_rows: List[dict],
-               img_schema: pa.Schema, face_schema: pa.Schema) -> None:
+               img_schema: pa.Schema, face_schema: pa.Schema,
+               ocr_rows: Optional[List[dict]] = None) -> None:
+        from .db import OCR_SCHEMA
+
         if image_rows:
             self.library.images.add(pa.Table.from_pylist(image_rows, schema=img_schema))
         if face_rows:
             self.library.faces.add(pa.Table.from_pylist(face_rows, schema=face_schema))
+        if ocr_rows:
+            self.library.ocr.add(pa.Table.from_pylist(ocr_rows, schema=OCR_SCHEMA))
 
 
 def _scale_bbox(bbox: Tuple[int, int, int, int], scale: float

--- a/photolib/ocr.py
+++ b/photolib/ocr.py
@@ -81,6 +81,56 @@ class RapidOcrBackend:
             return array[::step, ::step]
 
 
+class WindowsOcrBackend:
+    """Windows' built-in OCR (Windows.Media.Ocr) via the winsdk projection.
+
+    The engine behind PowerToys Text Extractor: ships with Windows, needs no
+    model download, and is an order of magnitude faster than running
+    PaddleOCR on CPU — ~0.25s for a dense screenshot against ~5s. Preferred
+    automatically on Windows; other platforms fall back to RapidOCR.
+    """
+
+    name = "windows"
+    model_name = "windows-media-ocr"
+    max_side = 2400   # well under the engine's 10k limit; keeps buffers sane
+
+    def __init__(self, max_chars: int = 4000):
+        from winsdk.windows.media.ocr import OcrEngine
+
+        self._engine = OcrEngine.try_create_from_user_profile_languages()
+        if self._engine is None:
+            raise RuntimeError(
+                "Windows OCR has no language pack installed for the current "
+                "user profile")
+        self.max_chars = max_chars
+
+    def extract(self, array: np.ndarray, path: Optional[str] = None) -> str:
+        import asyncio
+
+        result = asyncio.run(self._recognize(self._to_bitmap(array)))
+        lines = [line.text.strip() for line in result.lines if line.text.strip()]
+        return "\n".join(lines)[: self.max_chars]
+
+    async def _recognize(self, bitmap):
+        return await self._engine.recognize_async(bitmap)
+
+    @staticmethod
+    def _to_bitmap(array: np.ndarray):
+        from winsdk.windows.graphics.imaging import (BitmapPixelFormat,
+                                                     SoftwareBitmap)
+        from winsdk.windows.storage.streams import DataWriter
+
+        h, w = array.shape[:2]
+        bgra = np.dstack([
+            array[:, :, 2], array[:, :, 1], array[:, :, 0],
+            np.full((h, w), 255, dtype=np.uint8),
+        ])
+        writer = DataWriter()
+        writer.write_bytes(bgra.tobytes())
+        return SoftwareBitmap.create_copy_from_buffer(
+            writer.detach_buffer(), BitmapPixelFormat.BGRA8, w, h)
+
+
 class StubOcrBackend:
     """Deterministic OCR for tests: the filename's words are the "text".
 
@@ -91,6 +141,7 @@ class StubOcrBackend:
 
     name = "stub"
     model_name = "stub-ocr-v1"
+    max_side = 1280
 
     def extract(self, array: np.ndarray, path: Optional[str] = None) -> str:
         if not path:
@@ -99,12 +150,25 @@ class StubOcrBackend:
         return " ".join(part for part in stem.replace("_", "-").split("-") if part)
 
 
+def ocr_available() -> bool:
+    """Cheap availability probe, without loading any models."""
+    import importlib.util
+    import sys
+
+    if sys.platform == "win32" and importlib.util.find_spec("winsdk"):
+        return True
+    return importlib.util.find_spec("rapidocr_onnxruntime") is not None
+
+
 def build_ocr(settings=None) -> Optional[OcrBackend]:
     """The configured OCR engine, or None when text recognition is off.
 
-    ``auto`` quietly degrades to None when rapidocr is not installed —
-    OCR is an enhancement, never a requirement.
+    ``auto`` prefers the native Windows engine, falls back to RapidOCR, and
+    quietly degrades to None when neither is installed — OCR is an
+    enhancement, never a requirement.
     """
+    import sys
+
     from .config import get_settings
 
     settings = settings or get_settings()
@@ -114,6 +178,20 @@ def build_ocr(settings=None) -> Optional[OcrBackend]:
         return None
     if backend == "stub":
         return StubOcrBackend()
+
+    if backend in ("auto", "windows") and sys.platform == "win32":
+        try:
+            return WindowsOcrBackend(max_chars=settings.ocr_max_chars)
+        except Exception as exc:
+            if backend == "windows":
+                raise RuntimeError(
+                    f"Windows OCR is unavailable: {exc}. Install the winsdk "
+                    "package and a Windows language pack, or set "
+                    "PHOTO_OCR_BACKEND=rapidocr.") from exc
+            logger.info("Windows OCR unavailable (%s); trying RapidOCR", exc)
+    elif backend == "windows":
+        raise RuntimeError("PHOTO_OCR_BACKEND=windows only works on Windows")
+
     try:
         return RapidOcrBackend(
             min_confidence=settings.ocr_min_confidence,

--- a/photolib/ocr.py
+++ b/photolib/ocr.py
@@ -1,0 +1,135 @@
+"""Local text recognition (OCR) for screenshot-heavy libraries.
+
+Semantic embeddings are the wrong tool for finding the literal string
+"JROTC" rendered inside a screenshot: the base image model sees photos at
+224px, where UI text is illegible. OCR closes that gap — text is extracted
+once at index time, stored next to the image row, and exact matches rank
+ahead of semantic ones at search time.
+
+The default engine is RapidOCR, which runs PaddleOCR's detection and
+recognition models on onnxruntime — the same inference stack the rest of the
+application already ships. Its models are bundled inside the Python package,
+so the offline guarantee holds: nothing is downloaded at runtime.
+
+OCR is strictly optional. When the package is not installed the library
+behaves exactly as before, and the API reports the engine as unavailable.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import List, Optional, Protocol
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class OcrBackend(Protocol):
+    name: str
+    model_name: str
+
+    def extract(self, array: np.ndarray, path: Optional[str] = None) -> str:
+        """Text found in the image, reading-order lines joined by newlines."""
+        ...
+
+
+class RapidOcrBackend:
+    """PaddleOCR det+rec models via onnxruntime (the rapidocr package)."""
+
+    name = "rapidocr"
+    model_name = "ppocr-v4-onnx"
+
+    def __init__(self, min_confidence: float = 0.5, max_chars: int = 4000,
+                 max_side: int = 1280):
+        from rapidocr_onnxruntime import RapidOCR  # noqa: import guarded by build_ocr
+
+        self._engine = RapidOCR()
+        self.min_confidence = min_confidence
+        self.max_chars = max_chars
+        self.max_side = max_side
+
+    def extract(self, array: np.ndarray, path: Optional[str] = None) -> str:
+        img = self._shrink(array)
+        result, _ = self._engine(img)
+        if not result:
+            return ""
+        lines: List[str] = []
+        for entry in result:
+            # Each entry is [box, text, confidence].
+            text = str(entry[1]).strip()
+            confidence = float(entry[2]) if len(entry) > 2 else 1.0
+            if text and confidence >= self.min_confidence:
+                lines.append(text)
+        return "\n".join(lines)[: self.max_chars]
+
+    def _shrink(self, array: np.ndarray) -> np.ndarray:
+        """Bound the long edge — detection cost is quadratic in resolution."""
+        h, w = array.shape[:2]
+        long_edge = max(h, w)
+        if long_edge <= self.max_side:
+            return array
+        scale = self.max_side / long_edge
+        try:
+            import cv2
+
+            return cv2.resize(array, (int(w * scale), int(h * scale)),
+                              interpolation=cv2.INTER_AREA)
+        except Exception:
+            step = max(1, int(round(1 / scale)))
+            return array[::step, ::step]
+
+
+class StubOcrBackend:
+    """Deterministic OCR for tests: the filename's words are the "text".
+
+    Mirrors the stub embedder's convention, so a synthetic photo named
+    ``beach-sunset-holiday-20180704.jpg`` "contains" the text
+    ``beach sunset holiday 20180704`` without any model in CI.
+    """
+
+    name = "stub"
+    model_name = "stub-ocr-v1"
+
+    def extract(self, array: np.ndarray, path: Optional[str] = None) -> str:
+        if not path:
+            return ""
+        stem = Path(path).stem
+        return " ".join(part for part in stem.replace("_", "-").split("-") if part)
+
+
+def build_ocr(settings=None) -> Optional[OcrBackend]:
+    """The configured OCR engine, or None when text recognition is off.
+
+    ``auto`` quietly degrades to None when rapidocr is not installed —
+    OCR is an enhancement, never a requirement.
+    """
+    from .config import get_settings
+
+    settings = settings or get_settings()
+    backend = settings.ocr_backend
+
+    if backend == "off":
+        return None
+    if backend == "stub":
+        return StubOcrBackend()
+    try:
+        return RapidOcrBackend(
+            min_confidence=settings.ocr_min_confidence,
+            max_chars=settings.ocr_max_chars,
+            max_side=settings.ocr_max_side,
+        )
+    except ImportError:
+        if backend == "rapidocr":
+            raise RuntimeError(
+                "PHOTO_OCR_BACKEND=rapidocr but the rapidocr-onnxruntime "
+                "package is not installed. `pip install rapidocr-onnxruntime` "
+                "or set PHOTO_OCR_BACKEND=off.")
+        logger.info("OCR disabled: rapidocr-onnxruntime is not installed")
+        return None
+    except Exception as exc:
+        if backend == "rapidocr":
+            raise
+        logger.warning("OCR disabled: engine failed to initialise: %s", exc)
+        return None

--- a/photolib/service.py
+++ b/photolib/service.py
@@ -1183,11 +1183,10 @@ class PhotoService:
     # ------------------------------------------------------------------
     def ocr_status(self) -> dict:
         """Coverage and availability of text recognition."""
-        import importlib.util
+        from .ocr import ocr_available
 
         available = self.settings.ocr_backend != "off" and (
-            self.settings.ocr_backend == "stub"
-            or importlib.util.find_spec("rapidocr_onnxruntime") is not None)
+            self.settings.ocr_backend == "stub" or ocr_available())
         scanned = with_text = 0
         if self.ready and self.library.has_ocr():
             scanned = self.library.ocr.count_rows(None)
@@ -1245,7 +1244,8 @@ class PhotoService:
             for i, (image_id, path) in enumerate(todo):
                 text = ""
                 try:
-                    array = load_rgb_array(path, max_side=self.settings.ocr_max_side)
+                    array = load_rgb_array(path, max_side=getattr(
+                        backend, "max_side", self.settings.ocr_max_side))
                     text = backend.extract(array, path)
                 except Exception:
                     # Unreadable file: record an empty scan so the job

--- a/photolib/service.py
+++ b/photolib/service.py
@@ -104,19 +104,31 @@ class PhotoService:
         allowed = self.index.select(filters)
         has_query = bool(query and query.strip())
 
+        score_of: Dict[int, float] = {}
+        text_set: set = set()
         if has_query:
-            rows, scores = self._semantic_rows(query.strip(), allowed, min_score)
+            sem_rows, sem_scores = self._semantic_rows(
+                query.strip(), allowed, min_score)
+            # Exact text hits (from OCR) are the strongest possible signal for
+            # a literal query like "JROTC": the embedding model cannot read
+            # fine print, so text matches rank ahead of semantic ones.
+            text_rows = self._text_rows(query.strip(), allowed)
+            text_set = {int(r) for r in text_rows}
             if sort == "relevance":
-                ordered = rows
+                score_of = {int(r): float(s)
+                            for r, s in zip(sem_rows, sem_scores)}
+                rest = (sem_rows[~np.isin(sem_rows, text_rows)]
+                        if text_rows.size else sem_rows)
+                ordered = np.concatenate([
+                    self.index.order(text_rows, "date_desc"), rest,
+                ]).astype(np.int64)
             else:
-                # An explicit date/random sort re-orders the matches; relevance
-                # scores no longer describe the ordering, so drop them.
-                ordered, scores = self.index.order(rows, sort), None
+                union = np.union1d(sem_rows, text_rows).astype(np.int64)
+                ordered = self.index.order(union, sort)
         else:
             # "relevance" has no meaning without a query.
             ordered = self.index.order(
                 allowed, "date_desc" if sort == "relevance" else sort)
-            scores = None
 
         total = int(ordered.shape[0])
         start = (page - 1) * per_page
@@ -124,10 +136,12 @@ class PhotoService:
         image_ids = self.index.ids_of(window)
 
         results = self.hydrate(image_ids)
-        if scores is not None:
-            score_map = dict(zip(image_ids, scores[start:start + per_page].tolist()))
-            for item in results:
-                item["score"] = round(float(score_map.get(item["image_id"], 0.0)), 4)
+        if has_query:
+            for item, row in zip(results, window.tolist()):
+                if int(row) in text_set:
+                    item["text_match"] = True
+                elif score_of:
+                    item["score"] = round(score_of.get(int(row), 0.0), 4)
 
         return SearchPage(
             total=total, page=page, per_page=per_page, results=results,
@@ -138,6 +152,13 @@ class PhotoService:
                        min_score: Optional[float]) -> Tuple[np.ndarray, np.ndarray]:
         vector = self.embedder.embed_texts([query])[0]
         return self._vector_rows(vector, allowed, min_score)
+
+    def _text_rows(self, query: str, allowed: np.ndarray) -> np.ndarray:
+        """Rows whose OCR text contains every word of the query."""
+        tokens = [t for t in query.lower().split() if len(t) >= 2]
+        if not tokens:
+            return np.zeros(0, dtype=np.int64)
+        return self.index.text_match(tokens, allowed)
 
     def _vector_rows(self, vector: np.ndarray, allowed: np.ndarray,
                      min_score: Optional[float] = None,
@@ -295,7 +316,24 @@ class PhotoService:
             }
         details["people"] = list(seen.values())
         details["faces"] = faces
+        details["ocr_text"] = self._ocr_excerpt(image_id)
         return details
+
+    def _ocr_excerpt(self, image_id: int, limit: int = 800) -> str:
+        if not self.library.has_ocr():
+            return ""
+        try:
+            rows = (
+                self.library.ocr.search()
+                .where(f"image_id = {int(image_id)}")
+                .select(["text"])
+                .limit(1)
+                .to_arrow()
+                .to_pylist()
+            )
+        except Exception:
+            return ""
+        return (rows[0]["text"] or "")[:limit] if rows else ""
 
     def faces_in_image(self, image_id: int) -> List[dict]:
         rows = (
@@ -821,6 +859,7 @@ class PhotoService:
             "embed_model": f"{meta.embed_backend}:{meta.embed_model}" if meta else None,
             "embed_dim": meta.image_dim if meta else None,
             "face_model": f"{meta.face_backend}:{meta.face_model}" if meta else None,
+            "ocr": self.ocr_status(),
         }
 
     def timeline(self, filters: Optional[Filters] = None) -> List[dict]:
@@ -992,6 +1031,241 @@ class PhotoService:
         from .models import status
 
         return status(self.settings)
+
+    # ------------------------------------------------------------------
+    # Albums
+    # ------------------------------------------------------------------
+    def list_albums(self) -> List[dict]:
+        if not self.library.has_albums():
+            return []
+        albums = self.library.albums.to_lance().to_table().to_pylist()
+        counts: Dict[int, int] = {}
+        first_item: Dict[int, int] = {}
+        for row in self.library.album_items.to_lance().to_table(
+                columns=["album_id", "image_id"]).to_pylist():
+            aid = int(row["album_id"])
+            counts[aid] = counts.get(aid, 0) + 1
+            first_item.setdefault(aid, int(row["image_id"]))
+        out = []
+        for a in albums:
+            aid = int(a["album_id"])
+            cover = a["cover_image_id"]
+            cover = int(cover) if cover is not None and int(cover) >= 0 else \
+                first_item.get(aid, -1)
+            out.append({
+                "album_id": aid,
+                "name": a["name"] or f"Album {aid}",
+                "photo_count": counts.get(aid, 0),
+                "cover_image_id": cover,
+            })
+        out.sort(key=lambda a: (-a["photo_count"], a["album_id"]))
+        return out
+
+    def get_album(self, album_id: int) -> dict:
+        album = next((a for a in self.list_albums()
+                      if a["album_id"] == int(album_id)), None)
+        if album is None:
+            raise NotFound(f"Album {album_id} not found")
+        return album
+
+    def create_album(self, name: str) -> dict:
+        import pyarrow as pa
+
+        from .db import ALBUMS_SCHEMA
+
+        self.library.ensure_albums()
+        album_id = self.library.next_id("albums", "album_id")
+        self.library.albums.add(pa.Table.from_pylist([{
+            "album_id": int(album_id),
+            "name": name.strip() or f"Album {album_id}",
+            "created_at": now_ms(),
+            "cover_image_id": -1,
+        }], schema=ALBUMS_SCHEMA))
+        return self.get_album(album_id)
+
+    def rename_album(self, album_id: int, name: str) -> dict:
+        self.get_album(album_id)
+        self.library.albums.update(where=f"album_id = {int(album_id)}",
+                                   values={"name": name.strip()})
+        return self.get_album(album_id)
+
+    def delete_album(self, album_id: int) -> dict:
+        self.get_album(album_id)
+        self.library.album_items.delete(f"album_id = {int(album_id)}")
+        self.library.albums.delete(f"album_id = {int(album_id)}")
+        return {"deleted": int(album_id)}
+
+    def album_image_ids(self, album_id: int) -> List[int]:
+        """Album members, newest addition first."""
+        rows = (
+            self.library.album_items.search()
+            .where(f"album_id = {int(album_id)}")
+            .select(["image_id", "added_at"])
+            .limit(100_000)
+            .to_arrow()
+            .to_pylist()
+        )
+        rows.sort(key=lambda r: (r["added_at"] is not None, r["added_at"]),
+                  reverse=True)
+        return [int(r["image_id"]) for r in rows]
+
+    def album_detail(self, album_id: int, limit: int = 500) -> dict:
+        album = self.get_album(album_id)
+        ids = self.album_image_ids(album_id)[:limit]
+        return {**album, "images": self.hydrate(ids)}
+
+    def add_album_items(self, album_id: int, image_ids: Sequence[int]) -> dict:
+        import pyarrow as pa
+
+        from .db import ALBUM_ITEMS_SCHEMA
+
+        self.get_album(album_id)
+        existing = set(self.album_image_ids(album_id))
+        fresh = [int(i) for i in dict.fromkeys(int(i) for i in image_ids)
+                 if int(i) not in existing]
+        # Only accept photos the library actually knows.
+        fresh = [i for i in fresh if self.index.row_of(i) is not None]
+        if fresh:
+            added_at = now_ms()
+            self.library.album_items.add(pa.Table.from_pylist([
+                {"album_id": int(album_id), "image_id": i, "added_at": added_at}
+                for i in fresh], schema=ALBUM_ITEMS_SCHEMA))
+        return {"added": len(fresh), **self.get_album(album_id)}
+
+    def remove_album_items(self, album_id: int, image_ids: Sequence[int]) -> dict:
+        self.get_album(album_id)
+        ids = [int(i) for i in image_ids]
+        if ids:
+            id_list = ", ".join(str(i) for i in ids)
+            self.library.album_items.delete(
+                f"album_id = {int(album_id)} AND image_id IN ({id_list})")
+        return {"removed": len(ids), **self.get_album(album_id)}
+
+    def album_suggestions(self, album_id: int, limit: int = 24) -> List[dict]:
+        """Photos that look like this album, for one-click adding.
+
+        The album's visual identity is the mean of its members' embeddings —
+        crude but effective for the "keep adding beach photos" workflow.
+        """
+        self.get_album(album_id)
+        member_ids = self.album_image_ids(album_id)
+        if not member_ids:
+            return []
+        sample = member_ids[:32]   # newest members define the theme
+        id_list = ", ".join(str(i) for i in sample)
+        rows = (
+            self.library.images.search()
+            .where(f"image_id IN ({id_list})")
+            .select(["vector"])
+            .limit(len(sample))
+            .to_arrow()
+            .to_pylist()
+        )
+        if not rows:
+            return []
+        vectors = np.stack([np.asarray(r["vector"], dtype=np.float32)
+                            for r in rows])
+        centroid = vectors.mean(axis=0)
+        centroid /= max(float(np.linalg.norm(centroid)), 1e-12)
+
+        allowed = self.index.select(Filters())
+        member_rows = {self.index.row_of(i) for i in member_ids}
+        allowed = np.asarray([r for r in allowed if r not in member_rows],
+                             dtype=np.int64)
+        rows_found, scores = self._vector_rows(centroid, allowed, limit=limit)
+        results = self.hydrate(self.index.ids_of(rows_found[:limit]))
+        for item, score in zip(results, scores[:limit]):
+            item["score"] = round(float(score), 4)
+        return results
+
+    # ------------------------------------------------------------------
+    # OCR
+    # ------------------------------------------------------------------
+    def ocr_status(self) -> dict:
+        """Coverage and availability of text recognition."""
+        import importlib.util
+
+        available = self.settings.ocr_backend != "off" and (
+            self.settings.ocr_backend == "stub"
+            or importlib.util.find_spec("rapidocr_onnxruntime") is not None)
+        scanned = with_text = 0
+        if self.ready and self.library.has_ocr():
+            scanned = self.library.ocr.count_rows(None)
+            with_text = self.library.ocr.count_rows("text != ''")
+        return {
+            "available": available,
+            "backend": self.settings.ocr_backend,
+            "scanned": scanned,
+            "with_text": with_text,
+            "total_images": self.index.count if self.ready else 0,
+        }
+
+    def start_ocr_backfill_job(self):
+        """Extract text from every image that has never been scanned.
+
+        Incremental and safe to interrupt: each image gets exactly one OCR
+        row once scanned, so cancelling and re-running picks up where it
+        stopped — no re-embedding, no touching the images table.
+        """
+        from .ocr import build_ocr
+
+        backend = build_ocr(self.settings)
+        if backend is None:
+            raise ValueError(
+                "No OCR engine is available. Install rapidocr-onnxruntime "
+                "(pip install rapidocr-onnxruntime) and try again.")
+        self.require_ready()
+
+        def run(progress) -> dict:
+            import pyarrow as pa
+
+            from .db import OCR_SCHEMA
+            from .imageio import load_rgb_array
+
+            self.library.ensure_ocr()
+            done = {int(i) for i in self.library.ocr.to_lance().to_table(
+                columns=["image_id"])["image_id"].to_pylist()}
+            images = self.library.images.to_lance().to_table(
+                columns=["image_id", "path"]).to_pylist()
+            todo = [(int(r["image_id"]), str(r["path"])) for r in images
+                    if int(r["image_id"]) not in done]
+            # Newest first, so recent photos become text-searchable soonest.
+            todo.sort(key=lambda t: -t[0])
+
+            scanned = with_text = failed = 0
+            batch: List[dict] = []
+
+            def flush() -> None:
+                if batch:
+                    self.library.ocr.add(
+                        pa.Table.from_pylist(batch, schema=OCR_SCHEMA))
+                    batch.clear()
+
+            progress("scanning text", 0, len(todo), {})
+            for i, (image_id, path) in enumerate(todo):
+                text = ""
+                try:
+                    array = load_rgb_array(path, max_side=self.settings.ocr_max_side)
+                    text = backend.extract(array, path)
+                except Exception:
+                    # Unreadable file: record an empty scan so the job
+                    # converges instead of retrying it forever.
+                    failed += 1
+                batch.append({"image_id": image_id, "text": text,
+                              "engine": backend.name, "updated_at": now_ms()})
+                scanned += 1
+                if text:
+                    with_text += 1
+                if len(batch) >= 64:
+                    flush()
+                progress("scanning text", i + 1, len(todo),
+                         {"file": Path(path).name, "with_text": with_text})
+            flush()
+            self.index.invalidate()
+            return {"scanned": scanned, "with_text": with_text,
+                    "failed": failed, "already_scanned": len(done)}
+
+        return self.jobs.submit("ocr", run)
 
     def start_fetch_models_job(self):
         """Download any missing model weights, with progress.

--- a/photolib/service.py
+++ b/photolib/service.py
@@ -198,13 +198,14 @@ class PhotoService:
                      if "_distance" in table.column_names
                      else [0.0] * table.num_rows)
 
+        row_map = self.index.row_map()
         rows: List[int] = []
         scores: List[float] = []
         for image_id, distance in zip(hits, distances):
             image_id = int(image_id)
             if exclude_image_id is not None and image_id == exclude_image_id:
                 continue
-            row = self.index.row_of(image_id)
+            row = row_map.get(image_id)
             if row is None or not allowed_set[row]:
                 continue
             similarity = 1.0 - float(distance)

--- a/requirements-desktop.txt
+++ b/requirements-desktop.txt
@@ -4,7 +4,9 @@
 onnxruntime~=1.20.0
 tokenizers>=0.20,<0.23
 insightface==1.0.1
-# Text-in-photos search. Ships its ONNX models inside the wheel, so the
-# packaged app stays fully offline.
+# Text-in-photos search. On Windows the native Windows.Media.Ocr engine is
+# used (fast, no model download); RapidOCR is the cross-platform fallback
+# and ships its ONNX models inside the wheel, so both stay fully offline.
+winsdk~=1.0.0b10 ; sys_platform == 'win32'
 rapidocr-onnxruntime~=1.4.4
 pyinstaller~=6.21.0

--- a/requirements-desktop.txt
+++ b/requirements-desktop.txt
@@ -4,4 +4,7 @@
 onnxruntime~=1.20.0
 tokenizers>=0.20,<0.23
 insightface==1.0.1
+# Text-in-photos search. Ships its ONNX models inside the wheel, so the
+# packaged app stays fully offline.
+rapidocr-onnxruntime~=1.4.4
 pyinstaller~=6.21.0

--- a/tests/test_albums.py
+++ b/tests/test_albums.py
@@ -1,0 +1,66 @@
+"""Albums: CRUD, membership, and similarity-based suggestions."""
+
+from __future__ import annotations
+
+API = "/api/v1"
+
+
+def _ids(client, query=None, n=8):
+    body = client.post(f"{API}/search", json={"query": query, "per_page": n}).json()
+    return [r["image_id"] for r in body["results"]]
+
+
+def test_album_lifecycle(client):
+    created = client.post(f"{API}/albums", json={"name": "Holidays"}).json()
+    album_id = created["album_id"]
+    assert created["name"] == "Holidays"
+    assert created["photo_count"] == 0
+
+    image_ids = _ids(client)[:3]
+    added = client.post(f"{API}/albums/{album_id}/items",
+                        json={"image_ids": image_ids}).json()
+    assert added["added"] == 3
+    assert added["photo_count"] == 3
+
+    # Adding the same photos again is a no-op, not a duplicate.
+    again = client.post(f"{API}/albums/{album_id}/items",
+                        json={"image_ids": image_ids}).json()
+    assert again["added"] == 0
+    assert again["photo_count"] == 3
+
+    detail = client.get(f"{API}/albums/{album_id}").json()
+    assert {img["image_id"] for img in detail["images"]} == set(image_ids)
+
+    renamed = client.patch(f"{API}/albums/{album_id}",
+                           json={"name": "Trips"}).json()
+    assert renamed["name"] == "Trips"
+
+    removed = client.post(f"{API}/albums/{album_id}/items/remove",
+                          json={"image_ids": [image_ids[0]]}).json()
+    assert removed["photo_count"] == 2
+
+    listing = client.get(f"{API}/albums").json()["albums"]
+    assert any(a["album_id"] == album_id and a["cover_image_id"] >= 0
+               for a in listing)
+
+    client.delete(f"{API}/albums/{album_id}")
+    assert client.get(f"{API}/albums/{album_id}").status_code == 404
+
+
+def test_album_suggestions_exclude_members(client):
+    beach = _ids(client, "beach sunset holiday", 2)
+    album = client.post(f"{API}/albums", json={"name": "Beach"}).json()
+    client.post(f"{API}/albums/{album['album_id']}/items",
+                json={"image_ids": beach})
+
+    body = client.get(
+        f"{API}/albums/{album['album_id']}/suggestions?limit=10").json()
+    suggested = {s["image_id"] for s in body["suggestions"]}
+    assert suggested.isdisjoint(set(beach))
+    assert all("score" in s for s in body["suggestions"])
+
+
+def test_unknown_album_is_404(client):
+    assert client.get(f"{API}/albums/9999").status_code == 404
+    assert client.post(f"{API}/albums/9999/items",
+                       json={"image_ids": [1]}).status_code == 404

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -1,0 +1,117 @@
+"""OCR: index-time extraction, backfill, and text-first search ranking.
+
+Uses the stub OCR backend, which "reads" a photo's filename words as its
+text — the same convention as the stub embedder, so no models run in CI.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+@pytest.fixture
+def ocr_settings(settings, monkeypatch):
+    monkeypatch.setenv("PHOTO_OCR_BACKEND", "stub")
+    from photolib.config import get_settings, reset_settings_cache
+
+    reset_settings_cache()
+    s = get_settings()
+    s.ensure_dirs()
+    yield s
+    reset_settings_cache()
+
+
+@pytest.fixture
+def ocr_service(ocr_settings, library):
+    from photolib.service import PhotoService
+
+    return PhotoService(settings=ocr_settings, library=library)
+
+
+@pytest.fixture
+def ocr_indexed(ocr_service, photo_dir):
+    from photolib.indexer import Indexer
+
+    indexer = Indexer(ocr_service.library, ocr_service.settings,
+                      ocr_service.embedder, ocr_service.face_backend,
+                      ocr_service.thumbs)
+    indexer.index_directory(photo_dir)
+    ocr_service.index.invalidate()
+    return ocr_service
+
+
+def _wait(job, timeout=30):
+    deadline = time.time() + timeout
+    while job.status in ("pending", "running") and time.time() < deadline:
+        time.sleep(0.05)
+    return job
+
+
+def test_indexing_writes_one_ocr_row_per_image(ocr_indexed):
+    library = ocr_indexed.library
+    assert library.has_ocr()
+    assert library.ocr.count_rows(None) == library.images.count_rows(None)
+
+
+def test_text_matches_rank_ahead_of_semantic_results(ocr_indexed):
+    from photolib.browse import Filters
+
+    page = ocr_indexed.search("city street night", Filters(), sort="relevance")
+    assert page.results
+    top = page.results[0]
+    assert top["filename"] == "city-street-night-lights.jpg"
+    assert top.get("text_match") is True
+
+
+def test_ocr_text_appears_in_image_details(ocr_indexed):
+    from photolib.browse import Filters
+
+    page = ocr_indexed.search("beach sunset holiday", Filters(), sort="relevance")
+    details = ocr_indexed.image_details(page.results[0]["image_id"])
+    assert "beach" in details["ocr_text"]
+
+
+def test_backfill_scans_only_missing_images(settings, library, photo_dir,
+                                            monkeypatch):
+    """A library indexed before OCR existed gains text without re-indexing."""
+    from photolib.indexer import Indexer
+    from photolib.service import PhotoService
+
+    service = PhotoService(settings=settings, library=library)
+    assert service.settings.ocr_backend == "auto"  # resolves to None in CI
+    indexer = Indexer(library, settings, service.embedder,
+                      service.face_backend, service.thumbs)
+    indexer.index_directory(photo_dir)
+    service.index.invalidate()
+    assert not library.has_ocr() or library.ocr.count_rows(None) == 0
+
+    images_version = library.images.version
+
+    service.settings.ocr_backend = "stub"
+    job = _wait(service.start_ocr_backfill_job())
+    assert job.status == "done", job.error
+    assert job.result["scanned"] == 8
+    assert job.result["with_text"] == 8
+
+    # The images table was never rewritten — no re-embedding happened.
+    assert library.images.version == images_version
+
+    # A second run has nothing to do.
+    job = _wait(service.start_ocr_backfill_job())
+    assert job.status == "done"
+    assert job.result["scanned"] == 0
+    assert job.result["already_scanned"] == 8
+
+    from photolib.browse import Filters
+
+    page = service.search("snow winter skiing", Filters(), sort="relevance")
+    assert page.results[0]["filename"] == "snow-winter-skiing-20220211.jpg"
+    assert page.results[0].get("text_match") is True
+
+
+def test_stats_report_ocr_coverage(ocr_indexed):
+    stats = ocr_indexed.stats()
+    assert stats["ocr"]["scanned"] == 8
+    assert stats["ocr"]["available"] is True

--- a/tests/test_ocr.py
+++ b/tests/test_ocr.py
@@ -80,7 +80,8 @@ def test_backfill_scans_only_missing_images(settings, library, photo_dir,
     from photolib.service import PhotoService
 
     service = PhotoService(settings=settings, library=library)
-    assert service.settings.ocr_backend == "auto"  # resolves to None in CI
+    # Index with OCR explicitly off, as an old build would have.
+    service.settings.ocr_backend = "off"
     indexer = Indexer(library, settings, service.embedder,
                       service.face_backend, service.thumbs)
     indexer.index_directory(photo_dir)

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -34,7 +34,8 @@ def big_index() -> LibraryIndex:
     # and the arrays below stand in for a real 200k-row table.
     index._library = SimpleNamespace(images=SimpleNamespace(version=1))
     index._version = 1
-    index._ocr_version = None   # matches _ocr_table_version() on the stub library
+    index._ocr_handle = None    # no OCR table on the stub library
+    index._ocr_version = None
     index._built = True
 
     index.image_ids = np.arange(N, dtype=np.int64)

--- a/tests/test_scale.py
+++ b/tests/test_scale.py
@@ -34,6 +34,7 @@ def big_index() -> LibraryIndex:
     # and the arrays below stand in for a real 200k-row table.
     index._library = SimpleNamespace(images=SimpleNamespace(version=1))
     index._version = 1
+    index._ocr_version = None   # matches _ocr_table_version() on the stub library
     index._built = True
 
     index.image_ids = np.arange(N, dtype=np.int64)


### PR DESCRIPTION
## Summary

**Text in photos (OCR)** — the fix for semantic search underperforming on screenshots (e.g. "JROTC"):
- RapidOCR (PaddleOCR models on onnxruntime) — fully local, models ship inside the wheel, packaged app stays offline
- Extracted once per photo at index time from the already-decoded buffer; stored in a new lazily-created `ocr` table, so **existing libraries gain OCR via a backfill job with zero re-indexing/re-embedding**
- `POST /admin/ocr` backfills only never-scanned photos (newest first, incremental, cancellable, resumable)
- Hybrid ranking: photos whose text contains every query word rank ahead of semantic matches, marked with a TEXT badge; extracted text appears in the viewer's Details panel
- Optional dependency: without the package installed everything behaves as before

**Albums**
- `albums`/`album_items` tables (lazy), CRUD under `/albums`
- Per-album "looks like it belongs" suggestions from the mean member embedding, one-click add
- Albums tab (create, inline rename, two-step delete, hover-remove) + "Add to album" in the photo viewer

**QoL**
- Ctrl+V an image anywhere → reverse image search on the pasted image
- Merge review collapsed by default with a count badge (state remembered)
- `/` focuses search

## Test plan
- [x] 205 tests pass, including 8 new OCR/albums tests (stub OCR backend keeps CI model-free)
- [x] `node --check` on the UI
- [x] RapidOCR smoke test reads rendered "JROTC drill meet 2024" at 98.7% confidence
- [x] Backfill running against a real 2,814-photo library

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tme4Q3rGCXL333C8vyxba