### PR TITLE
Videos, keyboard shortcuts, copy/export, and AVIF

### DIFF
--- a/desktop/ui/app.css
+++ b/desktop/ui/app.css
@@ -153,6 +153,12 @@ button:disabled { cursor: not-allowed; opacity: .45; }
 .photo:hover .frame-no { opacity: 1; }
 .score { position: absolute; z-index: 1; top: 7px; right: 7px; padding: 2px 7px; border-radius: 999px; background: rgba(11,23,48,.78); color: var(--accent); }
 
+/* videos in the grid — the badge slides up when the hover meta appears */
+.video-badge { position: absolute; z-index: 1; right: 7px; bottom: 7px; padding: 2px 8px;
+  border-radius: 4px; background: rgba(0,0,0,.62); color: #fff; font-size: 11px;
+  letter-spacing: .04em; transition: bottom .2s ease; pointer-events: none; }
+.photo:hover .video-badge { bottom: 30px; }
+
 /* selection — the check circle takes the top-left corner, so the frame
    number steps aside on real tiles (skeletons keep it at the edge) */
 .select-check { position: absolute; z-index: 2; top: 7px; left: 7px; width: 22px; height: 22px;
@@ -188,11 +194,25 @@ button:disabled { cursor: not-allowed; opacity: .45; }
   cursor: zoom-in; user-select: none; touch-action: none; will-change: transform; }
 .modal-stage img.zoomed { cursor: grab; }
 .modal-stage img.zoomed.dragging { cursor: grabbing; }
+.modal-stage video { display: block; width: 100%; max-height: 72vh; background: #000; }
+.video-fallback { display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  margin: 8px 18px 0; padding: 10px 14px; border: 1px solid var(--line-soft);
+  border-radius: var(--radius); background: var(--surface); color: var(--muted); font-size: 13px; }
 .modal-close { position: absolute; z-index: 2; top: 12px; right: 12px; width: 40px; height: 40px; padding: 0; border-radius: 50%; color: #fff; border: 1px solid rgba(255,255,255,.22); background: rgba(0,0,0,.6); font-size: 20px; }
 .modal-info { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; padding: 14px 18px 6px; }
 .modal-text strong { display: block; font-size: 15px; }
 .modal-text .mono { display: block; margin-top: 4px; color: var(--faint); }
-.modal-buttons { display: flex; gap: 8px; flex-shrink: 0; }
+.modal-buttons { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; flex-shrink: 0; }
+.modal-text .mono.danger-text { color: #ff9d96; }
+
+/* keyboard cheat sheet (?) */
+.shortcut-card { width: min(560px, 100%); padding: 24px 28px 26px; }
+.shortcut-card h3 { margin: 0 0 16px; font-size: 16px; letter-spacing: .01em; }
+.shortcut-grid { display: grid; grid-template-columns: auto 1fr; gap: 10px 22px; align-items: center; font-size: 13px; color: var(--muted); }
+.shortcut-grid > span:nth-child(odd) { white-space: nowrap; color: var(--faint); }
+.kbd { display: inline-block; min-width: 22px; padding: 2px 8px; text-align: center;
+  border: 1px solid var(--line); border-bottom-width: 2px; border-radius: 5px;
+  background: var(--surface-2); color: var(--text); font-size: 11.5px; }
 
 .exif { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 4px 22px; margin: 8px 18px 4px; padding: 12px 14px; border: 1px solid var(--line-soft); border-radius: var(--radius); background: var(--surface); }
 .exif-row { display: flex; gap: 12px; align-items: baseline; padding: 3px 0; }

--- a/desktop/ui/app.js
+++ b/desktop/ui/app.js
@@ -33,6 +33,7 @@ const state = {
   selectionScope: "photos", // "photos" or "album" — where the picks live
   trashArmed: false,
   imageQuery: null,       // {url, label, blob} — active search-by-image chip
+  modalTrashArmed: false, // Delete pressed once in the viewer, awaiting confirm
 };
 
 const RECENT_KEY = "photolib.recentSearches";
@@ -125,6 +126,22 @@ function formatDate(value) {
   return Number.isNaN(date.valueOf())
     ? "no date"
     : date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+}
+
+function formatDuration(ms) {
+  const total = Math.max(0, Math.round((ms || 0) / 1000));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  return h
+    ? `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`
+    : `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function videoBadge(photo) {
+  return photo.media_type === "video"
+    ? `<span class="video-badge mono">▶ ${formatDuration(photo.duration_ms)}</span>`
+    : "";
 }
 
 function personLabel(person) {
@@ -495,6 +512,7 @@ function currentFilters() {
     people_ids: state.selectedPeople,
     people_mode: state.selectedPeople.length > 1 ? state.peopleMode : "any",
     camera: $("cameraFilter").value || null,
+    media: $("mediaFilter").value || null,
     has_location: $("locationToggle").checked ? true : null,
     untagged_only: state.untaggedOnly,
     near_lat: state.near ? state.near.lat : null,
@@ -508,6 +526,7 @@ function clearFilters() {
   $("dateFrom").value = "";
   $("dateTo").value = "";
   $("cameraFilter").value = "";
+  $("mediaFilter").value = "";
   $("locationToggle").checked = false;
   $("sortSelect").value = "relevance";
   state.selectedPeople = [];
@@ -604,6 +623,7 @@ function renderPhotos(result) {
         <img loading="lazy" src="${API}/images/${photo.image_id}/thumbnail?size=grid&format=webp" alt="${escapeHtml(photo.filename || "Photo")}">
         <span class="select-check" title="Select (Ctrl-click works too, Shift-click for a range)">✓</span>
         <span class="frame-no mono">${String(offset + i + 1).padStart(3, "0")}</span>
+        ${videoBadge(photo)}
         <span class="photo-meta mono">
           <span>${escapeHtml(formatDate(photo.taken_at))}</span>
           <span>${photo.face_count ? `${photo.face_count}👤` : ""}</span>
@@ -773,6 +793,58 @@ async function batchTrash() {
   }
 }
 
+async function batchExport() {
+  const ids = [...state.selection];
+  if (!ids.length) return;
+  const button = $("selExport");
+  const folder = await chooseFolder(false);
+  if (!folder) return;
+  button.disabled = true;
+  startLoad();
+  try {
+    const body = await request("/images/export", {
+      method: "POST",
+      body: JSON.stringify({ image_ids: ids, folder }),
+    });
+    button.textContent = `Copied ${body.copied} ✓`;
+    if (body.missing || body.failed?.length) {
+      showError(`${body.copied} copied — but ${body.missing || 0} original(s) are missing` +
+        `${body.failed?.length ? ` and ${body.failed.length} failed` : ""}.`);
+    }
+    setTimeout(() => { button.textContent = "Export copies…"; }, 2200);
+  } catch (error) {
+    showError(`Export failed: ${error.message}`);
+  } finally {
+    button.disabled = false;
+    endLoad();
+  }
+}
+
+function selectAllVisible() {
+  const albumOpen = state.view === "albums"
+    && !$("albumDetail").classList.contains("hidden");
+  const scope = albumOpen ? "album" : "photos";
+  const ids = albumOpen
+    ? (state.currentAlbum?.images || []).map((r) => r.image_id)
+    : state.results.map((r) => r.image_id);
+  if (!ids.length) return;
+  if (state.selectionScope !== scope) state.selection.clear();
+  state.selectionScope = scope;
+  ids.forEach((id) => state.selection.add(id));
+  state.selectionAnchor = 0;
+  reflectSelection();
+}
+
+// ---------------------------------------------------------------------------
+// Keyboard cheat sheet (?)
+// ---------------------------------------------------------------------------
+
+function toggleShortcuts(show) {
+  const modal = $("shortcutModal");
+  const wanted = show ?? modal.classList.contains("hidden");
+  modal.classList.toggle("hidden", !wanted);
+}
+
 // ---------------------------------------------------------------------------
 // Timeline
 // ---------------------------------------------------------------------------
@@ -819,15 +891,72 @@ function renderTimeline() {
 // Photo modal
 // ---------------------------------------------------------------------------
 
+// The stage shows either the <img> (with zoom/pan) or the <video>.
+function modalVideoActive() {
+  return !$("modalVideo").classList.contains("hidden");
+}
+
+function stopModalVideo() {
+  const video = $("modalVideo");
+  if (video.getAttribute("src")) {
+    video.pause();
+    delete video.dataset.imageId;   // cleared first: the load() below fires
+    video.removeAttribute("src");   // an error event we must ignore
+    video.removeAttribute("poster");
+    video.load();
+  }
+  video.classList.add("hidden");
+  $("videoFallback").classList.add("hidden");
+}
+
+function showModalMedia(imageId, isVideo) {
+  const img = $("modalImage");
+  const video = $("modalVideo");
+  $("modalCopyBtn").classList.toggle("hidden", Boolean(isVideo));
+  if (isVideo) {
+    if (img.getAttribute("src")) img.removeAttribute("src");
+    img.classList.add("hidden");
+    resetZoom();
+    if (video.dataset.imageId !== String(imageId)) {
+      $("videoFallback").classList.add("hidden");
+      video.dataset.imageId = String(imageId);
+      video.poster = `${API}/images/${imageId}/thumbnail?size=preview&format=jpeg`;
+      video.src = `${API}/images/${imageId}`;
+    }
+    video.classList.remove("hidden");
+  } else {
+    stopModalVideo();
+    img.classList.remove("hidden");
+    if (!img.getAttribute("src")) img.src = `${API}/images/${imageId}`;
+  }
+}
+
+function disarmModalTrash() {
+  if (!state.modalTrashArmed) return;
+  state.modalTrashArmed = false;
+  const meta = $("modalMeta");
+  meta.classList.remove("danger-text");
+  if (meta.dataset.prev != null) {
+    meta.textContent = meta.dataset.prev;
+    delete meta.dataset.prev;
+  }
+}
+
 async function openPhoto(imageId, filename = "") {
   state.modalIndex = state.results.findIndex((r) => r.image_id === Number(imageId));
   state.modalImageId = Number(imageId);
+  disarmModalTrash();
   updateModalNav();
   $("albumPickPanel").classList.add("hidden");
   $("modalAlbumBtn").textContent = "Add to album";
+  $("modalCopyBtn").textContent = "Copy image";
+  $("modalRevealBtn").textContent = "Show in Explorer";
   $("photoModal").classList.remove("hidden");
   resetZoom();
-  $("modalImage").src = `${API}/images/${imageId}`;
+  // The grid row usually knows the media type; details confirm it below.
+  const known = (state.modalIndex >= 0 ? state.results[state.modalIndex] : null)
+    || (state.currentAlbum?.images || []).find((r) => r.image_id === Number(imageId));
+  showModalMedia(imageId, known?.media_type === "video");
   $("modalName").textContent = filename || "Loading…";
   $("modalMeta").textContent = "";
   $("modalExif").classList.add("hidden");
@@ -840,11 +969,16 @@ async function openPhoto(imageId, filename = "") {
     closePhoto();
     showSimilar(imageId, filename);
   };
+  $("modalCopyBtn").onclick = () => copyModalImage(imageId, $("modalCopyBtn"));
+  $("modalRevealBtn").onclick = () => revealImage(imageId, $("modalRevealBtn"));
   try {
     const details = await request(`/images/${imageId}/details`);
+    if (state.modalImageId !== Number(imageId)) return; // user moved on
+    showModalMedia(imageId, details.media_type === "video");
     $("modalName").textContent = details.filename || "Photo";
     $("modalMeta").textContent = [
       formatDate(details.taken_at),
+      details.media_type === "video" ? formatDuration(details.duration_ms) : "",
       details.camera,
       details.width && details.height ? `${details.width}×${details.height}` : "",
     ].filter(Boolean).join(" · ").toUpperCase();
@@ -859,6 +993,7 @@ function renderExif(details) {
   const rows = [];
   const add = (key, value) => { if (value) rows.push([key, value]); };
   add("taken", details.taken_at ? new Date(details.taken_at).toLocaleString() : "");
+  add("length", details.media_type === "video" ? formatDuration(details.duration_ms) : "");
   add("camera", details.camera);
   add("size", details.width && details.height ? `${details.width} × ${details.height}` : "");
   add("file", details.file_size ? formatBytes(details.file_size) : "");
@@ -917,6 +1052,79 @@ async function copyImageText(imageId, button) {
     setTimeout(() => { button.textContent = "Copy text"; }, 1500);
   } catch (error) {
     showError(`Could not copy the text: ${error.message}`);
+  }
+}
+
+async function copyModalImage(imageId, button) {
+  // The preview-size JPEG re-encode is used as the source: unlike the
+  // original, it is decodable for every format (HEIC and RAW included).
+  try {
+    if (!navigator.clipboard || !window.ClipboardItem) {
+      throw new Error("the clipboard is not available here");
+    }
+    const img = new Image();
+    img.src = `${API}/images/${imageId}/thumbnail?size=preview&format=jpeg`;
+    await img.decode();
+    const canvas = document.createElement("canvas");
+    canvas.width = img.naturalWidth;
+    canvas.height = img.naturalHeight;
+    canvas.getContext("2d").drawImage(img, 0, 0);
+    const blob = await new Promise((resolve, reject) => canvas.toBlob(
+      (b) => (b ? resolve(b) : reject(new Error("could not encode the image"))),
+      "image/png"));
+    await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+    button.textContent = "Copied ✓";
+    setTimeout(() => { button.textContent = "Copy image"; }, 1500);
+  } catch (error) {
+    showError(`Could not copy the image: ${error.message}`);
+  }
+}
+
+async function revealImage(imageId, button) {
+  try {
+    await request(`/images/${imageId}/reveal`, { method: "POST" });
+    button.textContent = "Opened ✓";
+    setTimeout(() => { button.textContent = "Show in Explorer"; }, 1500);
+  } catch (error) {
+    showError(`Could not show the file: ${error.message}`);
+  }
+}
+
+async function trashOpenPhoto() {
+  const imageId = state.modalImageId;
+  if (imageId == null) return;
+  const meta = $("modalMeta");
+  if (!state.modalTrashArmed) {
+    state.modalTrashArmed = true;
+    meta.dataset.prev = meta.textContent;
+    meta.textContent = "PRESS DELETE AGAIN — MOVES THE FILE TO THE RECYCLE BIN";
+    meta.classList.add("danger-text");
+    setTimeout(disarmModalTrash, 4000);
+    return;
+  }
+  disarmModalTrash();
+  startLoad();
+  try {
+    const body = await request("/images/trash", {
+      method: "POST",
+      body: JSON.stringify({ image_ids: [imageId] }),
+    });
+    if (body.failed?.length) {
+      showError("The file could not be moved to the Recycle Bin — it stays in the library.");
+      return;
+    }
+    closePhoto();
+    state.selection.delete(imageId);
+    reflectSelection();
+    await Promise.all([loadStats(), loadPeople(), loadTimeline()]);
+    if (state.currentAlbum && !$("albumDetail").classList.contains("hidden")) {
+      openAlbum(state.currentAlbum.album_id);
+    }
+    if (state.view === "photos") search(state.page);
+  } catch (error) {
+    showError(`Trash failed: ${error.message}`);
+  } finally {
+    endLoad();
   }
 }
 
@@ -1005,11 +1213,13 @@ function initZoom() {
   const stage = $("modalStage");
   const img = $("modalImage");
   stage.addEventListener("wheel", (event) => {
+    if (modalVideoActive()) return; // the player owns its own gestures
     event.preventDefault();
     zoomTowards(event.clientX, event.clientY,
       Math.exp(-event.deltaY * 0.0016));
   }, { passive: false });
   stage.addEventListener("dblclick", (event) => {
+    if (modalVideoActive()) return; // double-click on a video = fullscreen
     if (zoom.scale > 1) resetZoom();
     else zoomTowards(event.clientX, event.clientY, 2.5);
   });
@@ -1038,6 +1248,8 @@ function initZoom() {
 function closePhoto() {
   $("photoModal").classList.add("hidden");
   $("modalImage").removeAttribute("src");
+  stopModalVideo();
+  disarmModalTrash();
   resetZoom();
 }
 
@@ -1845,6 +2057,7 @@ function renderAlbumPhotos(detail) {
     <div class="photo album-photo ${state.selection.has(photo.image_id) ? "selected" : ""}" data-image-id="${photo.image_id}" data-index="${i}">
       <img loading="lazy" src="${API}/images/${photo.image_id}/thumbnail?size=grid&format=webp" alt="${escapeHtml(photo.filename || "Photo")}">
       <span class="select-check" title="Select (Ctrl-click works too, Shift-click for a range)">✓</span>
+      ${videoBadge(photo)}
       <button class="album-remove mono" type="button" data-remove="${photo.image_id}" title="Remove from album">×</button>
     </div>
   `).join("");
@@ -2143,11 +2356,16 @@ async function importCuration(file) {
 
 async function loadStats() {
   const stats = await request("/stats");
-  $("topStats").textContent = [
-    `${(stats.total_images || 0).toLocaleString()} PHOTOS`,
+  const videos = stats.total_videos || 0;
+  const parts = [
+    `${((stats.total_images || 0) - videos).toLocaleString()} PHOTOS`,
+  ];
+  if (videos) parts.push(`${videos.toLocaleString()} VIDEOS`);
+  parts.push(
     `${(stats.total_people || 0).toLocaleString()} PEOPLE`,
     `${(stats.total_faces || 0).toLocaleString()} FACES`,
-  ].join(" · ");
+  );
+  $("topStats").textContent = parts.join(" · ");
 }
 
 async function loadCameras() {
@@ -2253,6 +2471,7 @@ async function init() {
   $("dateFrom").addEventListener("change", () => search(1));
   $("dateTo").addEventListener("change", () => search(1));
   $("cameraFilter").addEventListener("change", () => search(1));
+  $("mediaFilter").addEventListener("change", () => search(1));
   $("locationToggle").addEventListener("change", () => search(1));
   $("clearFilters").addEventListener("click", clearFilters);
   $("similarClear").addEventListener("click", () => {
@@ -2324,6 +2543,7 @@ async function init() {
 
   $("selClear").addEventListener("click", clearSelection);
   $("selTrash").addEventListener("click", batchTrash);
+  $("selExport").addEventListener("click", batchExport);
   $("selRemoveAlbum").addEventListener("click", batchRemoveFromAlbum);
   $("selAlbumBtn").addEventListener("click", () => toggleSelectionAlbumPanel());
   $("selAlbumCreate").addEventListener("submit", async (event) => {
@@ -2343,12 +2563,27 @@ async function init() {
   });
   initZoom();
 
+  $("shortcutClose").addEventListener("click", () => toggleShortcuts(false));
+  $("shortcutModal").addEventListener("click", (event) => {
+    if (event.target === $("shortcutModal")) toggleShortcuts(false);
+  });
+  $("modalVideo").addEventListener("error", () => {
+    // Fires for real decode failures (e.g. HEVC without the Windows codec)
+    // and also when a source is detached — dataset.imageId separates them.
+    const imageId = $("modalVideo").dataset.imageId;
+    if (!imageId) return;
+    $("videoFallbackLink").href = `${API}/images/${imageId}?download=true`;
+    $("videoFallback").classList.remove("hidden");
+  });
+
   document.addEventListener("keydown", (event) => {
     const photoOpen = !$("photoModal").classList.contains("hidden");
+    const typing = ["INPUT", "TEXTAREA", "SELECT"].includes(event.target.tagName);
     if (event.key === "Escape") {
       // Close only the topmost layer, so backing out of a photo opened
       // from a person still leaves the person open.
-      if (photoOpen) closePhoto();
+      if (!$("shortcutModal").classList.contains("hidden")) toggleShortcuts(false);
+      else if (photoOpen) closePhoto();
       else if (!$("personModal").classList.contains("hidden")) closePerson();
       else if (!$("selAlbumPanel").classList.contains("hidden")) {
         toggleSelectionAlbumPanel(false);
@@ -2356,13 +2591,52 @@ async function init() {
       else togglePeoplePanel(false);
       return;
     }
-    if (photoOpen && event.key === "ArrowRight") navigatePhoto(1);
-    if (photoOpen && event.key === "ArrowLeft") navigatePhoto(-1);
-    if (event.key === "/" && !photoOpen
-        && !["INPUT", "TEXTAREA", "SELECT"].includes(event.target.tagName)) {
+    if (typing) return; // every other key below is a shortcut, not input
+
+    if (event.key === "?") {
+      event.preventDefault();
+      toggleShortcuts();
+      return;
+    }
+    if (event.key === "/" && !photoOpen) {
       event.preventDefault();
       setView("photos");
       $("searchInput").focus();
+      return;
+    }
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "a") {
+      if (photoOpen) return;
+      const albumOpen = state.view === "albums"
+        && !$("albumDetail").classList.contains("hidden");
+      if (state.view === "photos" || albumOpen) {
+        event.preventDefault();
+        selectAllVisible();
+      }
+      return;
+    }
+    if (event.key === "Delete") {
+      if (photoOpen) trashOpenPhoto();
+      else if (state.selection.size) batchTrash();
+      return;
+    }
+    if (!photoOpen) return;
+    if (event.key === "ArrowRight") navigatePhoto(1);
+    if (event.key === "ArrowLeft") navigatePhoto(-1);
+    if (event.target.tagName === "VIDEO") return; // native controls own these
+    if (event.key === " " && modalVideoActive()) {
+      event.preventDefault();
+      const video = $("modalVideo");
+      if (video.paused) video.play();
+      else video.pause();
+      return;
+    }
+    if (!modalVideoActive()) {
+      const rect = $("modalStage").getBoundingClientRect();
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      if (event.key === "+" || event.key === "=") zoomTowards(cx, cy, 1.3);
+      if (event.key === "-" || event.key === "_") zoomTowards(cx, cy, 1 / 1.3);
+      if (event.key === "0") resetZoom();
     }
   });
 

--- a/desktop/ui/index.html
+++ b/desktop/ui/index.html
@@ -94,6 +94,11 @@
             <input id="dateFrom" class="field slim" type="date" aria-label="Taken after" title="Taken after">
             <input id="dateTo" class="field slim" type="date" aria-label="Taken before" title="Taken before">
             <select id="cameraFilter" class="select slim hidden" aria-label="Camera"><option value="">Any camera</option></select>
+            <select id="mediaFilter" class="select slim" aria-label="Photos or videos">
+              <option value="">Photos + videos</option>
+              <option value="image">Photos only</option>
+              <option value="video">Videos only</option>
+            </select>
             <label class="toggle mono" id="locationToggleWrap" title="Only photos with GPS data">
               <input id="locationToggle" type="checkbox"> has location
             </label>
@@ -253,6 +258,11 @@
       <button id="modalNext" class="modal-nav next hidden" type="button" aria-label="Next photo">›</button>
       <div id="modalStage" class="modal-stage" title="Scroll to zoom · double-click to toggle · drag to pan">
         <img id="modalImage" alt="Full-size photo" draggable="false">
+        <video id="modalVideo" class="hidden" controls playsinline preload="metadata" aria-label="Video player"></video>
+      </div>
+      <div id="videoFallback" class="video-fallback hidden">
+        <span>This video's codec isn't supported by the built-in player. The file itself is fine.</span>
+        <a id="videoFallbackLink" class="btn slim-btn" href="#" download>Open the original</a>
       </div>
       <div class="modal-info">
         <div class="modal-text">
@@ -261,6 +271,8 @@
         </div>
         <div class="modal-buttons">
           <button id="modalDetailsBtn" class="btn ghost" type="button">Details</button>
+          <button id="modalCopyBtn" class="btn ghost" type="button" title="Copy the picture to the clipboard">Copy image</button>
+          <button id="modalRevealBtn" class="btn ghost" type="button" title="Show the original file in Explorer">Show in Explorer</button>
           <button id="modalSimilar" class="btn ghost" type="button">More like this</button>
           <div class="album-add">
             <button id="modalAlbumBtn" class="btn ghost" type="button" aria-haspopup="true" aria-expanded="false">Add to album</button>
@@ -300,8 +312,28 @@
         </div>
       </div>
       <button id="selRemoveAlbum" class="btn hidden" type="button">Remove from album</button>
+      <button id="selExport" class="btn" type="button" title="Copy the selected originals into a folder you pick">Export copies…</button>
       <button id="selTrash" class="btn danger-solid" type="button">Trash</button>
       <button id="selClear" class="btn ghost" type="button" title="Or press Escape">Clear</button>
+    </div>
+  </div>
+
+  <div id="shortcutModal" class="modal hidden" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts">
+    <div class="modal-card shortcut-card">
+      <button id="shortcutClose" class="modal-close" type="button" aria-label="Close shortcuts">×</button>
+      <h3>Keyboard shortcuts</h3>
+      <div class="shortcut-grid">
+        <span><span class="kbd mono">/</span></span><span>Jump to search</span>
+        <span><span class="kbd mono">Ctrl</span>+click · <span class="kbd mono">Shift</span>+click</span><span>Select photos · select a range</span>
+        <span><span class="kbd mono">Ctrl</span>+<span class="kbd mono">A</span></span><span>Select everything on this page</span>
+        <span><span class="kbd mono">Delete</span></span><span>Move to the Recycle Bin — press twice to confirm</span>
+        <span><span class="kbd mono">←</span> <span class="kbd mono">→</span></span><span>Previous / next photo in the viewer</span>
+        <span><span class="kbd mono">+</span> <span class="kbd mono">−</span> <span class="kbd mono">0</span></span><span>Zoom in / out / reset in the viewer</span>
+        <span><span class="kbd mono">Space</span></span><span>Play or pause a video</span>
+        <span><span class="kbd mono">Ctrl</span>+<span class="kbd mono">V</span></span><span>Paste an image to search by it</span>
+        <span><span class="kbd mono">Esc</span></span><span>Close the top layer · clear the selection</span>
+        <span><span class="kbd mono">?</span></span><span>Show or hide this list</span>
+      </div>
     </div>
   </div>
 

--- a/docs/superpowers/specs/2026-07-26-video-and-polish-design.md
+++ b/docs/superpowers/specs/2026-07-26-video-and-polish-design.md
@@ -1,0 +1,135 @@
+# Videos, shortcuts, and getting things out — Round 7 design
+
+Approved bundle: (1) video support end to end, (2) keyboard shortcuts with a
+discoverable cheat sheet, (3) copy image / Show in Explorer / export copies,
+(4) AVIF. Everything stays local and offline.
+
+## 1. Video support
+
+### The one structural decision
+
+Videos are **rows in the existing `images` table**, not a parallel system.
+A video is represented by its *poster frame* — a frame pulled from ~1s in —
+and that frame flows through the exact same pipeline as a photo: SigLIP
+embedding (semantic search), face detection (people), perceptual hash
+(duplicates), OCR, thumbnails. Two new columns describe what makes it a
+video: `media_type` ("image" | "video") and `duration_ms`.
+
+This buys, for free: search, people, albums, trash, duplicates, curation
+backup, multi-select — every existing feature works on videos with no new
+code paths.
+
+### Decode layer (`photolib/imageio.py`)
+
+- `VIDEO_EXTS = {.mp4 .mov .m4v .webm .mkv .avi .3gp .mpg .mpeg .wmv .mts .m2ts}`,
+  included in `SUPPORTED_EXTS` only when `imageio-ffmpeg` imports; otherwise
+  videos are skipped with one warning (same pattern as pillow-heif).
+- `open_image(path)` grows a video branch: seek to `min(1s, duration/2)`,
+  decode one frame via `imageio_ffmpeg.read_frames`, return it as a PIL
+  image capped at 1920px long edge. A small keyed-by-`(path, mtime)` LRU
+  (8 entries) absorbs the fact that `_prepare` + thumbnails decode the same
+  file several times; cache returns copies so callers may close them.
+- `probe_video(path)` → `{duration_ms, width, height}` from the ffmpeg meta
+  dict (no frame decode); LRU-cached the same way. `read_size` uses it.
+- ffmpeg auto-rotates .mov display-matrix rotation during decode, so poster
+  orientation is correct without EXIF handling.
+
+### Metadata (`photolib/exif.py`)
+
+`read_metadata` gets a video branch: parse `creation_time` from
+`ffmpeg -i` stderr (validated: `creation_time   : 2023-05-17T14:30:00.000000Z`).
+The existing fallback chain (filename date, year sanity check) applies
+unchanged. GPS in videos is out of scope this round.
+
+### Schema and migration (`photolib/db.py`)
+
+- `images_schema` gains `media_type` (string) and `duration_ms` (int64).
+- `Library.ensure_media_columns()`: if `media_type` missing from the images
+  table schema, `add_columns({"media_type": "'image'", "duration_ms": ...})`
+  — an in-place backfill, no re-embed, no version bump (same philosophy as
+  the OCR table). Called from `PhotoService.__init__` and
+  `Indexer.index_directory`; `LibraryIndex._rebuild` additionally tolerates
+  the columns being absent so a read-only open of an old library never dies.
+- The user's real library needs **no re-index**: next "Index new files" run
+  simply discovers videos as new files.
+
+### Browse and API
+
+- `Filters.media: Optional[str]` ("image"/"video"); `LibraryIndex` keeps a
+  `media_type` array; the filter is one boolean mask. Search request schema
+  passes it through.
+- `IMAGE_LIST_COLUMNS` += `media_type`, `duration_ms` → every result row and
+  `image_details` carry them automatically.
+- `GET /images/{id}` already serves the original through Starlette's
+  `FileResponse`, which supports HTTP Range (installed starlette 1.3.1), so
+  `<video>` seeking works. Add video MIME types to `MIME_BY_SUFFIX`.
+- Stats gain a `videos` count.
+
+### Player UI
+
+- Tiles: ▶ badge + `m:ss` duration overlay for `media_type === "video"`.
+- Viewer: videos render a native `<video controls autoplay>` element (same
+  stage as the zoom container; zoom applies to images only). Native controls
+  give play/pause/scrub/volume/fullscreen. `canplay`/`error` events decide
+  the fallback: on decode failure (e.g. HEVC without the Windows codec),
+  show the poster thumbnail with an explanatory note and a "Download /
+  open in your player" link to the original-file URL.
+- Filter bar: "Videos" toggle chip → `media` filter.
+
+### Packaging
+
+`imageio-ffmpeg` added to requirements (min + desktop); PyInstaller spec
+collects the wheel's bundled `ffmpeg-win-x86_64*.exe` via
+`collect_data_files("imageio_ffmpeg")`. ~31MB — the price of playing half
+of everyone's camera roll.
+
+## 2. Keyboard shortcuts + cheat sheet
+
+| Key | Context | Action |
+| --- | --- | --- |
+| `Delete` | selection active, or viewer open | two-step trash (arm → confirm), same flow as the button |
+| `Ctrl+A` | photos grid or album open | select everything on the current page |
+| `+` / `-` / `0` | viewer, image | zoom in / out / reset |
+| `Space` | viewer, video | play/pause |
+| `?` | anywhere | shortcut cheat-sheet overlay |
+| existing | | `/` search, `←`/`→` navigate, `Esc` close/clear |
+
+The `?` overlay is a small modal listing all of the above; Escape closes it
+first (it joins the front of the existing Escape priority chain). Shortcuts
+never fire while an input/textarea has focus.
+
+## 3. Getting things out
+
+- **Copy image** (viewer): fetch the preview-size JPEG, draw to canvas,
+  `ClipboardItem` PNG. Works for HEIC/RAW too because the preview endpoint
+  re-encodes. Button next to Copy text with the same "Copied ✓" feedback.
+- **Show in Explorer** (viewer): `POST /images/{id}/reveal` runs
+  `explorer /select,<path>`. Desktop-only affordance, local-only endpoint;
+  module-level `_reveal_in_explorer` seam so tests stub it (the
+  `_send_to_trash` pattern).
+- **Export copies** (selection bar): `POST /images/export` with
+  `{image_ids, dest}`; dest comes from the existing native folder picker
+  endpoint. `shutil.copy2` (keeps timestamps); name collisions get
+  ` (2)`-style suffixes; response reports `{copied, missing, failed}`.
+  Originals are never touched or moved.
+
+## 4. AVIF
+
+Pillow 12 decodes AVIF natively (`features.check("avif")` is true in this
+venv). Add `.avif` to `RASTER_EXTS` gated on that check, plus the MIME
+entry. Nothing else changes.
+
+## Testing
+
+- **Video fixture**: `imageio_ffmpeg.write_frames` synthesizes tiny mp4s in
+  CI (validated) — solid-color frames keyed to filename words so the stub
+  embedder convention still holds; a `creation_time` tag tests date extraction.
+- Tests: video indexed with correct media_type/duration/taken_at; searchable
+  via stub; thumbnail generated from poster; media filter; Range request on
+  the file endpoint returns 206; trash/albums work on a video row.
+- Migration test: build a library with the old schema (drop the two columns)
+  → `ensure_media_columns` backfills, browse works, old rows are "image".
+- reveal/export: stub seam records calls; export collision-rename covered;
+  unknown ids and missing files counted, not fatal.
+- AVIF: generated `.avif` indexes end to end (skipped if Pillow lacks codec).
+- UI: `node --check`; live smoke test on the real library.

--- a/packaging/photolib.spec
+++ b/packaging/photolib.spec
@@ -47,6 +47,14 @@ except Exception as exc:
     print(f"WARNING: rapidocr not bundled ({exc}); "
           "text-in-photos search will be unavailable", file=sys.stderr)
 
+# imageio-ffmpeg carries the ffmpeg executable as package data — that binary
+# is what indexes and poster-frames videos. Without it, videos are skipped.
+try:
+    datas += collect_data_files("imageio_ffmpeg")
+except Exception as exc:
+    print(f"WARNING: imageio-ffmpeg not bundled ({exc}); "
+          "videos will not be indexed", file=sys.stderr)
+
 hiddenimports = [
     "uvicorn.logging",
     "uvicorn.loops.auto",
@@ -66,6 +74,8 @@ hiddenimports = [
     "send2trash",
     "send2trash.win",
     "send2trash.win.modern",
+    # Video indexing and playback posters.
+    "imageio_ffmpeg",
 ]
 
 # Nothing here uses PyTorch — the ONNX backend is the entire point. Excluding

--- a/photolib/api/routers/images.py
+++ b/photolib/api/routers/images.py
@@ -15,7 +15,7 @@ from ...config import get_settings
 from ...service import PhotoService
 from ...thumbnails import SIZES
 from ..deps import get_service, translate_errors
-from ..schemas import TrashRequest
+from ..schemas import ExportRequest, TrashRequest
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/images", tags=["images"])
@@ -34,11 +34,39 @@ def trash_images(req: TrashRequest,
     except Exception as exc:
         raise translate_errors(exc)
 
+
+@router.post("/export")
+def export_images(req: ExportRequest,
+                  service: PhotoService = Depends(get_service)):
+    """Copy originals into a folder of the user's choosing.
+
+    Purely additive: sources are never moved, renamed, or overwritten.
+    """
+    try:
+        return service.export_images(req.image_ids, req.folder)
+    except Exception as exc:
+        raise translate_errors(exc)
+
+
+@router.post("/{image_id}/reveal")
+def reveal_image(image_id: int, service: PhotoService = Depends(get_service)):
+    """Open the OS file manager with this file selected. Local desktop only."""
+    try:
+        return service.reveal_image(image_id)
+    except Exception as exc:
+        raise translate_errors(exc)
+
+
 MIME_BY_SUFFIX = {
     ".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png",
     ".webp": "image/webp", ".gif": "image/gif", ".heic": "image/heic",
     ".heif": "image/heif", ".tif": "image/tiff", ".tiff": "image/tiff",
-    ".bmp": "image/bmp",
+    ".bmp": "image/bmp", ".avif": "image/avif",
+    # FileResponse supports HTTP Range, which is what lets <video> seek.
+    ".mp4": "video/mp4", ".m4v": "video/mp4", ".mov": "video/quicktime",
+    ".webm": "video/webm", ".mkv": "video/x-matroska", ".avi": "video/x-msvideo",
+    ".3gp": "video/3gpp", ".mpg": "video/mpeg", ".mpeg": "video/mpeg",
+    ".wmv": "video/x-ms-wmv", ".mts": "video/mp2t", ".m2ts": "video/mp2t",
 }
 
 

--- a/photolib/api/routers/search.py
+++ b/photolib/api/routers/search.py
@@ -35,6 +35,7 @@ def _filters(req: SearchRequest) -> Filters:
         near_lat=req.near_lat,
         near_lon=req.near_lon,
         near_km=req.near_km,
+        media=req.media,
     )
 
 

--- a/photolib/api/schemas.py
+++ b/photolib/api/schemas.py
@@ -25,6 +25,7 @@ class SearchRequest(BaseModel):
     near_lat: Optional[float] = Field(None, ge=-90, le=90)
     near_lon: Optional[float] = Field(None, ge=-180, le=180)
     near_km: float = Field(1.0, gt=0, le=20000)
+    media: Optional[Literal["image", "video"]] = None
     sort: SortOption = "relevance"
     page: int = Field(1, ge=1)
     per_page: Optional[int] = Field(None, ge=1, le=1000)
@@ -51,6 +52,8 @@ class ImageSummary(BaseModel):
     face_count: int = 0
     width: int = 0
     height: int = 0
+    media_type: str = "image"
+    duration_ms: int = 0
     score: Optional[float] = None
     # True when the query matched text found in the image (OCR).
     text_match: Optional[bool] = None
@@ -141,6 +144,11 @@ class AlbumItemsRequest(BaseModel):
 
 class TrashRequest(BaseModel):
     image_ids: List[int] = Field(..., min_length=1, max_length=500)
+
+
+class ExportRequest(BaseModel):
+    image_ids: List[int] = Field(..., min_length=1, max_length=500)
+    folder: str = Field(..., min_length=1)
 
 
 class ReclusterRequest(BaseModel):

--- a/photolib/browse.py
+++ b/photolib/browse.py
@@ -46,6 +46,8 @@ class Filters:
     near_lat: Optional[float] = None
     near_lon: Optional[float] = None
     near_km: float = 1.0
+    # "image" or "video"; None = both.
+    media: Optional[str] = None
 
     @property
     def is_empty(self) -> bool:
@@ -53,7 +55,7 @@ class Filters:
                 and not self.people_ids and self.has_location is None
                 and self.has_faces is None and not self.folder
                 and not self.camera and not self.untagged_only
-                and self.near_lat is None)
+                and self.near_lat is None and self.media is None)
 
 
 class LibraryIndex:
@@ -73,6 +75,7 @@ class LibraryIndex:
         self.lat = np.zeros(0, dtype=np.float64)
         self.lon = np.zeros(0, dtype=np.float64)
         self.face_count = np.zeros(0, dtype=np.int32)
+        self.is_video = np.zeros(0, dtype=bool)
         self.folders: List[str] = []
         self.cameras: List[str] = []
         self.ocr_text: List[str] = []          # lowercase; "" = none/unscanned
@@ -114,9 +117,15 @@ class LibraryIndex:
             self._version = None
 
     def _rebuild(self, version: Optional[int]) -> None:
-        table = self._library.images.to_lance().to_table(
-            columns=["image_id", "taken_at", "added_at", "lat", "lon",
-                     "face_count", "people_ids", "folder", "camera"])
+        images = self._library.images
+        columns = ["image_id", "taken_at", "added_at", "lat", "lon",
+                   "face_count", "people_ids", "folder", "camera"]
+        # A library indexed before video support lacks this column until its
+        # next indexing run migrates it; browsing must not require a write.
+        has_media = "media_type" in images.schema.names
+        if has_media:
+            columns.append("media_type")
+        table = images.to_lance().to_table(columns=columns)
         n = table.num_rows
         logger.debug("Rebuilding browse index over %d images", n)
 
@@ -130,6 +139,12 @@ class LibraryIndex:
             _floats(table["face_count"]), nan=0.0).astype(np.int32)
         self.folders = [f or "" for f in table["folder"].to_pylist()]
         self.cameras = [c or "" for c in table["camera"].to_pylist()]
+        if has_media:
+            self.is_video = np.fromiter(
+                (m == "video" for m in table["media_type"].to_pylist()),
+                dtype=bool, count=n)
+        else:
+            self.is_video = np.zeros(n, dtype=bool)
 
         self._row_of_id = {int(v): i for i, v in enumerate(self.image_ids)}
 
@@ -270,6 +285,9 @@ class LibraryIndex:
         if filters.has_faces is not None:
             has = self.face_count > 0
             mask &= has if filters.has_faces else ~has
+
+        if filters.media:
+            mask &= self.is_video if filters.media == "video" else ~self.is_video
 
         if filters.untagged_only:
             tagged = np.zeros(n, dtype=bool)

--- a/photolib/db.py
+++ b/photolib/db.py
@@ -45,7 +45,7 @@ UNASSIGNED = -1  # person_id for a face that belongs to no person yet
 # is the single easiest way to make this system feel slow.
 IMAGE_LIST_COLUMNS = [
     "image_id", "path", "filename", "taken_at", "lat", "lon", "place",
-    "people_ids", "face_count", "width", "height",
+    "people_ids", "face_count", "width", "height", "media_type", "duration_ms",
 ]
 
 BROWSE_COLUMNS = ["image_id", "taken_at", "people_ids", "lat", "lon", "face_count"]
@@ -74,6 +74,10 @@ def images_schema(dim: int) -> pa.Schema:
         pa.field("camera", pa.string()),
         pa.field("people_ids", pa.list_(pa.int32())),
         pa.field("face_count", pa.int32()),
+        # "image" or "video". A video row's vector/faces/phash all come from
+        # its poster frame, so every image feature works on it unchanged.
+        pa.field("media_type", pa.string()),
+        pa.field("duration_ms", pa.int64()),
     ])
 
 
@@ -229,6 +233,28 @@ class Library:
     def initialised(self) -> bool:
         names = set(self.table_names())
         return {IMAGES, FACES, PEOPLE, META}.issubset(names)
+
+    def ensure_media_columns(self) -> None:
+        """Backfill media_type/duration_ms on libraries indexed before videos.
+
+        An in-place ``add_columns`` — every existing row becomes an "image",
+        no re-embedding, no schema version bump. Same philosophy as the OCR
+        table: old libraries gain the feature without a rebuild.
+        """
+        with self._lock:
+            if IMAGES not in self.table_names():
+                return
+            tbl = self._db.open_table(IMAGES)
+            names = set(tbl.schema.names)
+            additions = {}
+            if "media_type" not in names:
+                additions["media_type"] = "'image'"
+            if "duration_ms" not in names:
+                additions["duration_ms"] = "CAST(0 AS BIGINT)"
+            if additions:
+                tbl.add_columns(additions)
+                logger.info("Backfilled media columns on images: %s",
+                            sorted(additions))
 
     # -- metadata --------------------------------------------------------
     def read_meta(self) -> Optional[LibraryMeta]:

--- a/photolib/exif.py
+++ b/photolib/exif.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional, Tuple
 
-from .imageio import HEIF_EXTS, RAW_EXTS, register_heif
+from .imageio import HEIF_EXTS, RAW_EXTS, VIDEO_EXTS, register_heif
 
 logger = logging.getLogger(__name__)
 
@@ -184,7 +184,13 @@ def read_metadata(path) -> PhotoMetadata:
 
     meta = PhotoMetadata()
     try:
-        if suffix in RAW_EXTS:
+        if suffix in VIDEO_EXTS:
+            # Container metadata, not EXIF: capture time comes from the
+            # (UTC) creation_time tag, converted to local wall-clock time.
+            from .imageio import probe_video
+
+            meta = PhotoMetadata(taken_at=probe_video(path).taken_at)
+        elif suffix in RAW_EXTS:
             meta = _from_exifread(path)
         else:
             meta = _from_pillow(path)

--- a/photolib/imageio.py
+++ b/photolib/imageio.py
@@ -1,14 +1,22 @@
-"""Image loading helpers shared by the indexer, the API, and the models.
+"""Image and video loading helpers shared by the indexer, the API, and models.
 
 Centralised so that EXIF orientation, HEIC support, and the "don't decode a
 45-megapixel file to make a 150px thumbnail" trick are applied identically
-everywhere.
+everywhere. Videos join the same pipeline through their *poster frame*: a
+frame pulled from ~1 second in, which is what gets embedded, face-scanned,
+hashed, and thumbnailed — so every image feature works on videos unchanged.
 """
 
 from __future__ import annotations
 
+import io
 import logging
 import os
+import re
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime
+from functools import lru_cache
 from pathlib import Path
 from typing import Iterator, Optional, Tuple
 
@@ -24,7 +32,21 @@ _HEIF_REGISTERED = False
 RASTER_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif", ".bmp", ".tif", ".tiff"}
 HEIF_EXTS = {".heic", ".heif", ".hif"}
 RAW_EXTS = {".cr2", ".cr3", ".nef", ".arw", ".dng", ".orf", ".rw2", ".raf"}
+# AVIF decodes through Pillow >= 11.2 wheels; gated on a runtime check so an
+# older Pillow skips the files instead of failing every one of them.
+AVIF_EXTS = {".avif"}
+# Videos need the ffmpeg binary bundled with imageio-ffmpeg; without it they
+# are skipped with a single warning, the same deal as pillow-heif.
+VIDEO_EXTS = {".mp4", ".mov", ".m4v", ".webm", ".mkv", ".avi", ".3gp",
+              ".mpg", ".mpeg", ".wmv", ".mts", ".m2ts"}
 SUPPORTED_EXTS = RASTER_EXTS | HEIF_EXTS | RAW_EXTS
+
+# Long edge for decoded poster frames. Everything downstream (embedding,
+# faces, thumbnails) wants 1600px or less, so decoding 4K pixels is waste.
+POSTER_MAX_SIDE = 1920
+
+# Keep ffmpeg from opening a console window inside the packaged GUI app.
+_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0) if os.name == "nt" else 0
 
 # Pillow refuses very large images by default as a decompression-bomb guard.
 # Family libraries legitimately contain panoramas and scans, so raise the
@@ -46,8 +68,45 @@ def register_heif() -> None:
         logger.warning("pillow-heif unavailable, HEIC files will be skipped: %s", exc)
 
 
+@lru_cache(maxsize=1)
+def avif_supported() -> bool:
+    try:
+        from PIL import features
+
+        return bool(features.check("avif"))
+    except Exception:  # pragma: no cover - version dependent
+        return False
+
+
+@lru_cache(maxsize=1)
+def ffmpeg_exe() -> Optional[str]:
+    """Path to the bundled ffmpeg, or None when videos can't be handled."""
+    try:
+        import imageio_ffmpeg
+
+        return imageio_ffmpeg.get_ffmpeg_exe()
+    except Exception as exc:  # pragma: no cover - optional dependency
+        logger.warning("imageio-ffmpeg unavailable, videos will be skipped: %s", exc)
+        return None
+
+
+def video_supported() -> bool:
+    return ffmpeg_exe() is not None
+
+
+def is_video(path: os.PathLike | str) -> bool:
+    return Path(path).suffix.lower() in VIDEO_EXTS
+
+
 def is_supported(path: os.PathLike | str) -> bool:
-    return Path(path).suffix.lower() in SUPPORTED_EXTS
+    suffix = Path(path).suffix.lower()
+    if suffix in SUPPORTED_EXTS:
+        return True
+    if suffix in AVIF_EXTS:
+        return avif_supported()
+    if suffix in VIDEO_EXTS:
+        return video_supported()
+    return False
 
 
 def iter_image_files(root: os.PathLike | str, follow_symlinks: bool = False) -> Iterator[Path]:
@@ -69,13 +128,123 @@ def iter_image_files(root: os.PathLike | str, follow_symlinks: bool = False) -> 
                 yield p
 
 
+# -- video probing and poster frames ------------------------------------
+
+@dataclass(frozen=True)
+class VideoInfo:
+    duration_ms: int
+    width: int          # display dimensions, rotation already applied
+    height: int
+    taken_at: Optional[datetime]
+
+
+_DURATION_RE = re.compile(r"Duration:\s*(\d+):(\d\d):(\d\d(?:\.\d+)?)")
+_VIDEO_STREAM_RE = re.compile(r"Stream .*Video:.*?(\d{2,5})x(\d{2,5})")
+_ROTATION_RE = re.compile(r"rotation of (-?\d+(?:\.\d+)?) degrees|rotate\s*:\s*(-?\d+)")
+_CREATION_RE = re.compile(r"creation_time\s*:\s*(\S+)")
+
+
+def _run_ffmpeg(args: list, timeout: float = 60.0) -> subprocess.CompletedProcess:
+    exe = ffmpeg_exe()
+    if exe is None:
+        raise RuntimeError("ffmpeg is not available")
+    return subprocess.run([exe, *args], capture_output=True, timeout=timeout,
+                          creationflags=_NO_WINDOW)
+
+
+@lru_cache(maxsize=512)
+def _probe_cached(path: str, mtime_ns: int) -> VideoInfo:
+    # `ffmpeg -i` with no output exits non-zero by design; the stream
+    # banner on stderr is all we want.
+    proc = _run_ffmpeg(["-i", path], timeout=30.0)
+    text = proc.stderr.decode("utf-8", errors="replace")
+
+    duration_ms = 0
+    m = _DURATION_RE.search(text)
+    if m:
+        h, mi, s = int(m.group(1)), int(m.group(2)), float(m.group(3))
+        duration_ms = int(round((h * 3600 + mi * 60 + s) * 1000))
+
+    width = height = 0
+    m = _VIDEO_STREAM_RE.search(text)
+    if m:
+        width, height = int(m.group(1)), int(m.group(2))
+
+    m = _ROTATION_RE.search(text)
+    if m:
+        angle = abs(int(float(m.group(1) or m.group(2)))) % 360
+        if angle in (90, 270):
+            width, height = height, width
+
+    taken_at = None
+    m = _CREATION_RE.search(text)
+    if m:
+        raw = m.group(1)
+        try:
+            parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+            # Stored as UTC; photos carry local wall-clock times, so convert.
+            taken_at = parsed.astimezone().replace(tzinfo=None)
+        except ValueError:
+            logger.debug("Unparseable creation_time %r in %s", raw, path)
+
+    return VideoInfo(duration_ms=duration_ms, width=width, height=height,
+                     taken_at=taken_at)
+
+
+def probe_video(path: os.PathLike | str) -> VideoInfo:
+    """Duration, display size, and capture time — no frame decode."""
+    p = Path(path)
+    return _probe_cached(str(p), p.stat().st_mtime_ns)
+
+
+@lru_cache(maxsize=8)
+def _poster_cached(path: str, mtime_ns: int) -> Image.Image:
+    """Decode one representative frame as a PIL image.
+
+    PNG-over-pipe rather than rawvideo: the PNG carries its own dimensions,
+    so ffmpeg's automatic display-rotation can never scramble a reshape.
+    Cached because one indexing pass reads the poster several times (phash,
+    embedding buffer, thumbnails); callers get copies via _video_poster.
+    """
+    info = _probe_cached(path, mtime_ns)
+    seek = min(1.0, info.duration_ms / 2000.0) if info.duration_ms else 0.0
+
+    scale_args: list = []
+    if info.width and info.height and max(info.width, info.height) > POSTER_MAX_SIDE:
+        factor = POSTER_MAX_SIDE / max(info.width, info.height)
+        tw = max(2, int(info.width * factor)) // 2 * 2
+        th = max(2, int(info.height * factor)) // 2 * 2
+        scale_args = ["-vf", f"scale={tw}:{th}"]
+
+    for attempt_seek in ([seek, 0.0] if seek > 0 else [0.0]):
+        args = ["-ss", f"{attempt_seek:.3f}", "-i", path, "-frames:v", "1",
+                *scale_args, "-f", "image2pipe", "-c:v", "png", "-"]
+        proc = _run_ffmpeg(args)
+        if proc.returncode == 0 and proc.stdout:
+            img = Image.open(io.BytesIO(proc.stdout))
+            img.load()
+            if img.mode != "RGB":
+                img = img.convert("RGB")
+            return img
+    raise ValueError(
+        f"Could not decode a frame from {path}: "
+        f"{proc.stderr.decode('utf-8', errors='replace')[-300:]}")
+
+
+def _video_poster(path: os.PathLike | str) -> Image.Image:
+    p = Path(path)
+    return _poster_cached(str(p), p.stat().st_mtime_ns).copy()
+
+
 def open_image(path: os.PathLike | str, target: Optional[Tuple[int, int]] = None) -> Image.Image:
-    """Open an image as RGB with EXIF orientation applied.
+    """Open an image — or a video's poster frame — as RGB, oriented.
 
     ``target`` enables JPEG draft mode: libjpeg decodes straight to a reduced
     resolution, which is several times faster and uses a fraction of the
     memory when all we need is a thumbnail or a 224px model input.
     """
+    if is_video(path):
+        return _video_poster(path)
     register_heif()
     img = Image.open(path)
     try:
@@ -94,6 +263,12 @@ def open_image(path: os.PathLike | str, target: Optional[Tuple[int, int]] = None
 
 def read_size(path: os.PathLike | str) -> Tuple[int, int]:
     """(width, height) without decoding pixel data."""
+    if is_video(path):
+        info = probe_video(path)
+        if info.width and info.height:
+            return info.width, info.height
+        with _video_poster(path) as poster:
+            return poster.size
     register_heif()
     with Image.open(path) as img:
         w, h = img.size

--- a/photolib/indexer.py
+++ b/photolib/indexer.py
@@ -84,6 +84,8 @@ class _Prepared:
     lat: Optional[float]
     lon: Optional[float]
     camera: str
+    media_type: str = "image"
+    duration_ms: int = 0
     array: Optional[np.ndarray] = None
     error: Optional[str] = None
 
@@ -141,6 +143,7 @@ class Indexer:
             self.library.create(meta, drop_existing=rebuild)
         else:
             self.library.verify_compatible(meta)
+            self.library.ensure_media_columns()
 
         self.progress("scanning", 0, 0, {"root": str(root)})
         files = list(iter_image_files(root, self.settings.follow_symlinks))
@@ -339,6 +342,8 @@ class Indexer:
         stats.people_created = max(0, len(assigner.people) - people_before)
 
     def _prepare(self, path: Path) -> _Prepared:
+        from .imageio import is_video, probe_video
+
         try:
             st = path.stat()
             meta = read_metadata(path)
@@ -346,6 +351,9 @@ class Indexer:
             with open_image(path, target=(64, 64)) as small:
                 perceptual = phash(small)
             width, height = self._true_size(path, array)
+            video = is_video(path)
+            # Probe results are cached, so this re-read costs nothing.
+            duration = probe_video(path).duration_ms if video else 0
             return _Prepared(
                 path=str(path),
                 filename=path.name,
@@ -360,6 +368,8 @@ class Indexer:
                 lat=meta.lat,
                 lon=meta.lon,
                 camera=meta.camera,
+                media_type="video" if video else "image",
+                duration_ms=duration,
                 array=array,
             )
         except Exception as exc:
@@ -446,6 +456,8 @@ class Indexer:
             "camera": prep.camera,
             "people_ids": [int(p) for p in people_ids],
             "face_count": face_count,
+            "media_type": prep.media_type,
+            "duration_ms": prep.duration_ms,
         }
 
     @staticmethod

--- a/photolib/service.py
+++ b/photolib/service.py
@@ -36,6 +36,22 @@ def _send_to_trash(path: str) -> None:
     send2trash(path)
 
 
+def _reveal_in_file_manager(path: str) -> None:
+    """Open the OS file manager with the file selected. Module-level test seam."""
+    import subprocess
+    import sys
+
+    if os.name == "nt":
+        # explorer exits 1 even on success, so no return-code check.
+        subprocess.Popen(
+            ["explorer", f"/select,{path}"],
+            creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0))
+    elif sys.platform == "darwin":  # pragma: no cover - platform specific
+        subprocess.Popen(["open", "-R", path])
+    else:  # pragma: no cover - platform specific
+        subprocess.Popen(["xdg-open", os.path.dirname(path)])
+
+
 class NotFound(LookupError):
     pass
 
@@ -59,6 +75,13 @@ class PhotoService:
         self.settings = settings or get_settings()
         self.settings.ensure_dirs()
         self.library = library or Library(self.settings.db_uri)
+        if self.library.initialised():
+            # Libraries indexed before video support gain the media columns
+            # in place — cheap, idempotent, and no re-index.
+            try:
+                self.library.ensure_media_columns()
+            except Exception as exc:
+                logger.warning("Media column migration failed: %s", exc)
         self.index = LibraryIndex(self.library)
         self.thumbs = ThumbnailCache(self.settings.thumbnail_cache_dir)
         self.jobs = JobManager(self.settings.state_dir)
@@ -880,6 +903,7 @@ class PhotoService:
                 f"person_id = {UNASSIGNED}"),
             "images_with_location": int((~np.isnan(self.index.lat)).sum()),
             "images_with_faces": int((self.index.face_count > 0).sum()),
+            "total_videos": int(self.index.is_video.sum()),
             "images_without_date": int(np.isnan(self.index.taken_ts).sum()),
             "earliest_date": _iso(dated.min()) if dated.size else None,
             "latest_date": _iso(dated.max()) if dated.size else None,
@@ -985,6 +1009,63 @@ class PhotoService:
         self.index.invalidate()
         return {"trashed": trashed, "missing": missing,
                 "removed": len(removable), "failed": failed}
+
+    # ------------------------------------------------------------------
+    # Getting files out (reveal, export copies)
+    # ------------------------------------------------------------------
+    def reveal_image(self, image_id: int) -> dict:
+        """Show the original in the OS file manager (Explorer on Windows)."""
+        path = self.image_path(image_id)
+        if not os.path.exists(path):
+            raise NotFound(f"Indexed file is missing from disk: {path}")
+        _reveal_in_file_manager(path)
+        return {"revealed": path}
+
+    def export_images(self, image_ids: Sequence[int], folder: str) -> dict:
+        """Copy originals into ``folder``. Sources are never moved or altered.
+
+        Name collisions get " (2)"-style suffixes rather than overwriting;
+        a file already missing from disk is counted, not fatal.
+        """
+        self.require_ready()
+        ids = list(dict.fromkeys(int(i) for i in image_ids))
+        dest_dir = Path(folder).expanduser()
+        if not dest_dir.is_dir():
+            raise ValueError(f"Export folder does not exist: {folder}")
+
+        id_list = ", ".join(str(i) for i in ids)
+        rows = (
+            self.library.images.search()
+            .where(f"image_id IN ({id_list})")
+            .select(["image_id", "path"])
+            .limit(len(ids))
+            .to_arrow()
+            .to_pylist()
+        )
+        path_of = {int(r["image_id"]): str(r["path"]) for r in rows}
+
+        import shutil
+
+        copied = missing = 0
+        failed: List[dict] = []
+        for image_id in ids:
+            source = path_of.get(image_id)
+            if source is None or not os.path.exists(source):
+                missing += 1
+                continue
+            target = dest_dir / Path(source).name
+            try:
+                if target.exists() and os.path.samefile(source, target):
+                    # Exporting a photo into its own folder is a no-op,
+                    # not a reason to mint "name (2).jpg".
+                    copied += 1
+                    continue
+                shutil.copy2(source, _collision_free(target))
+                copied += 1
+            except Exception as exc:
+                failed.append({"image_id": image_id, "error": str(exc)})
+        return {"copied": copied, "missing": missing, "failed": failed,
+                "folder": str(dest_dir)}
 
     def _people_in_images(self, image_ids: Sequence[int]) -> List[int]:
         if not image_ids:
@@ -1597,6 +1678,17 @@ class PhotoService:
                         where=where, values_sql={"people_ids": "make_array()"})
 
 
+def _collision_free(target: Path) -> Path:
+    """First free name: photo.jpg, photo (2).jpg, photo (3).jpg, ..."""
+    if not target.exists():
+        return target
+    for n in range(2, 10_000):
+        candidate = target.with_name(f"{target.stem} ({n}){target.suffix}")
+        if not candidate.exists():
+            return candidate
+    raise FileExistsError(f"No free filename for {target}")
+
+
 def _image_dict(row) -> dict:
     people = row.get("people_ids")
     if people is None:
@@ -1613,6 +1705,8 @@ def _image_dict(row) -> dict:
         "face_count": int(row.get("face_count") or 0),
         "width": int(row.get("width") or 0),
         "height": int(row.get("height") or 0),
+        "media_type": row.get("media_type") or "image",
+        "duration_ms": int(row.get("duration_ms") or 0),
     }
 
 

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -14,3 +14,8 @@ ExifRead>=3.0
 tqdm>=4.66
 # Deleting photos goes through the OS trash, never a hard unlink.
 Send2Trash>=1.8
+# Bundled ffmpeg binary — videos are indexed by their poster frame and
+# served for in-app playback. Optional at runtime: without it, videos
+# are skipped with a warning.
+imageio-ffmpeg>=0.5
+

--- a/tests/test_export_reveal.py
+++ b/tests/test_export_reveal.py
@@ -1,0 +1,115 @@
+"""Getting files out: Show in Explorer and export-copies-to-folder.
+
+Neither operation may ever touch an original: reveal only points the OS file
+manager at it, and export writes new copies with collision-safe names.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+API = "/api/v1"
+
+
+@pytest.fixture
+def reveal_calls(monkeypatch):
+    calls: list = []
+    monkeypatch.setattr("photolib.service._reveal_in_file_manager", calls.append)
+    return calls
+
+
+def _ids(client, n=3):
+    body = client.post(f"{API}/search", json={"per_page": 20}).json()
+    return [r["image_id"] for r in body["results"][:n]]
+
+
+def _path_of(client, image_id):
+    details = client.get(f"{API}/images/{image_id}/details").json()
+    return Path(details["folder"]) / details["filename"]
+
+
+def test_reveal_points_at_the_original(client, reveal_calls):
+    image_id = _ids(client, 1)[0]
+    r = client.post(f"{API}/images/{image_id}/reveal")
+    assert r.status_code == 200
+    assert reveal_calls == [str(_path_of(client, image_id))]
+
+
+def test_reveal_unknown_image_is_404(client, reveal_calls):
+    assert client.post(f"{API}/images/987654/reveal").status_code == 404
+    assert reveal_calls == []
+
+
+def test_reveal_missing_file_is_404(client, reveal_calls):
+    image_id = _ids(client, 1)[0]
+    os.remove(_path_of(client, image_id))
+    assert client.post(f"{API}/images/{image_id}/reveal").status_code == 404
+    assert reveal_calls == []
+
+
+def test_export_copies_and_never_moves(client, tmp_path):
+    ids = _ids(client)
+    sources = [_path_of(client, i) for i in ids]
+    dest = tmp_path / "export-out"
+    dest.mkdir()
+
+    body = client.post(f"{API}/images/export",
+                       json={"image_ids": ids, "folder": str(dest)}).json()
+    assert body["copied"] == 3
+    assert body["missing"] == 0 and body["failed"] == []
+
+    copied = sorted(p.name for p in dest.iterdir())
+    assert copied == sorted(s.name for s in sources)
+    for source in sources:
+        assert source.exists()  # originals untouched
+
+
+def test_export_renames_instead_of_overwriting(client, tmp_path):
+    ids = _ids(client)
+    dest = tmp_path / "export-out"
+    dest.mkdir()
+
+    first = client.post(f"{API}/images/export",
+                        json={"image_ids": ids, "folder": str(dest)}).json()
+    second = client.post(f"{API}/images/export",
+                         json={"image_ids": ids, "folder": str(dest)}).json()
+    assert first["copied"] == 3 and second["copied"] == 3
+    names = [p.name for p in dest.iterdir()]
+    assert len(names) == 6
+    assert sum(1 for n in names if "(2)" in n) == 3
+
+
+def test_export_counts_missing_originals(client, tmp_path):
+    ids = _ids(client)
+    os.remove(_path_of(client, ids[0]))
+    dest = tmp_path / "export-out"
+    dest.mkdir()
+
+    body = client.post(f"{API}/images/export",
+                       json={"image_ids": ids, "folder": str(dest)}).json()
+    assert body["copied"] == 2
+    assert body["missing"] == 1
+
+
+def test_export_into_a_missing_folder_is_400(client, tmp_path):
+    ids = _ids(client, 1)
+    r = client.post(f"{API}/images/export",
+                    json={"image_ids": ids,
+                          "folder": str(tmp_path / "nope" / "nowhere")})
+    assert r.status_code == 400
+
+
+def test_export_into_the_source_folder_makes_no_duplicate(client):
+    """Exporting a photo to its own folder is a no-op, not a '(2)' copy."""
+    image_id = _ids(client, 1)[0]
+    source = _path_of(client, image_id)
+    before = sorted(p.name for p in source.parent.iterdir())
+
+    body = client.post(f"{API}/images/export",
+                       json={"image_ids": [image_id],
+                             "folder": str(source.parent)}).json()
+    assert body["copied"] == 1
+    assert sorted(p.name for p in source.parent.iterdir()) == before

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -1,0 +1,219 @@
+"""Videos and AVIF join the library through the existing image pipeline.
+
+A video is represented by its poster frame, so search, thumbnails, people,
+albums, and trash all work on it unchanged. Test videos are synthesized with
+the ffmpeg bundled in imageio-ffmpeg — solid-colour frames, with the filename
+carrying the searchable words (the stub-embedder convention).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+pytest.importorskip("imageio_ffmpeg")
+
+API = "/api/v1"
+
+
+def make_video(path: Path, seconds: float = 2.0, fps: int = 10,
+               size=(64, 48), color=(200, 60, 60),
+               creation_time: str | None = None) -> Path:
+    import imageio_ffmpeg
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    output_params = []
+    if creation_time:
+        output_params += ["-metadata", f"creation_time={creation_time}"]
+    writer = imageio_ffmpeg.write_frames(str(path), size, fps=fps,
+                                         codec="libx264",
+                                         output_params=output_params)
+    writer.send(None)
+    frame = np.zeros((size[1], size[0], 3), dtype=np.uint8)
+    frame[:, :] = color
+    for _ in range(int(seconds * fps)):
+        writer.send(frame.tobytes())
+    writer.close()
+    return path
+
+
+@pytest.fixture
+def media_dir(photo_dir: Path) -> Path:
+    """The sample photo library plus two videos."""
+    make_video(photo_dir / "puppy-fetch-video-20230530.mp4",
+               creation_time="2023-05-30T08:00:00Z")
+    make_video(photo_dir / "nested" / "concert-stage-crowd.mp4",
+               color=(40, 30, 90))
+    return photo_dir
+
+
+@pytest.fixture
+def media_client(client, indexer, indexed_service, media_dir):
+    """The standard client, after an incremental rescan picks up the videos."""
+    indexer.index_directory(media_dir)
+    indexed_service.index.invalidate()
+    return client
+
+
+# -- indexing ---------------------------------------------------------------
+
+def test_videos_index_with_type_and_duration(indexer, indexed_service, media_dir):
+    from photolib.browse import Filters
+
+    stats = indexer.index_directory(media_dir)
+    assert stats.added == 2  # the 8 photos are already indexed and skipped
+    indexed_service.index.invalidate()
+
+    page = indexed_service.search(None, Filters(media="video"))
+    assert page.total == 2
+    puppy = next(r for r in page.results if r["filename"].startswith("puppy"))
+    assert puppy["media_type"] == "video"
+    assert 1500 <= puppy["duration_ms"] <= 2500
+
+
+def test_video_ranks_for_its_words(indexer, indexed_service, media_dir):
+    from photolib.browse import Filters
+
+    indexer.index_directory(media_dir)
+    indexed_service.index.invalidate()
+    page = indexed_service.search("puppy fetch video", Filters(),
+                                  sort="relevance")
+    assert page.results[0]["filename"] == "puppy-fetch-video-20230530.mp4"
+
+
+def test_capture_time_comes_from_the_container(tmp_path):
+    from photolib.exif import read_metadata
+
+    tagged = make_video(tmp_path / "clip-tagged.mp4",
+                        creation_time="2023-05-30T08:00:00Z")
+    meta = read_metadata(tagged)
+    # Stored UTC, converted to local wall-clock — the date can shift by one
+    # day in extreme timezones, but never out of May 2023.
+    assert meta.taken_at is not None
+    assert (meta.taken_at.year, meta.taken_at.month) == (2023, 5)
+
+    untagged = make_video(tmp_path / "clip-plain.mp4")
+    assert read_metadata(untagged).taken_at is None
+
+    named = make_video(tmp_path / "ski-trip-20220211.mp4")
+    assert read_metadata(named).taken_at.year == 2022  # filename fallback
+
+
+def test_probe_reports_size_and_duration(tmp_path):
+    from photolib.imageio import probe_video, read_size
+
+    clip = make_video(tmp_path / "clip.mp4", seconds=1.5, size=(64, 48))
+    info = probe_video(clip)
+    assert (info.width, info.height) == (64, 48)
+    assert 1000 <= info.duration_ms <= 2000
+    assert read_size(clip) == (64, 48)
+
+
+# -- API --------------------------------------------------------------------
+
+def _video_id(client) -> int:
+    body = client.post(f"{API}/search",
+                       json={"media": "video", "per_page": 5}).json()
+    assert body["results"], "no videos in the test library"
+    return body["results"][0]["image_id"]
+
+
+def test_file_endpoint_supports_range_requests(media_client):
+    """<video> seeking depends on 206 partial responses."""
+    video_id = _video_id(media_client)
+    r = media_client.get(f"{API}/images/{video_id}",
+                         headers={"Range": "bytes=0-99"})
+    assert r.status_code == 206
+    assert r.headers["content-range"].startswith("bytes 0-99/")
+    assert r.headers["content-type"] == "video/mp4"
+    assert len(r.content) == 100
+
+    full = media_client.get(f"{API}/images/{video_id}")
+    assert full.status_code == 200
+
+
+def test_video_thumbnail_is_its_poster_frame(media_client):
+    video_id = _video_id(media_client)
+    r = media_client.get(f"{API}/images/{video_id}/thumbnail?size=grid")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "image/webp"
+
+
+def test_details_carry_media_fields(media_client):
+    video_id = _video_id(media_client)
+    details = media_client.get(f"{API}/images/{video_id}/details").json()
+    assert details["media_type"] == "video"
+    assert details["duration_ms"] > 0
+
+
+def test_media_filter_separates_photos_from_videos(media_client):
+    images = media_client.post(f"{API}/search",
+                               json={"media": "image", "per_page": 50}).json()
+    assert images["total"] == 8
+    assert all(r["media_type"] == "image" for r in images["results"])
+
+    everything = media_client.post(f"{API}/search",
+                                   json={"per_page": 50}).json()
+    assert everything["total"] == 10
+
+
+def test_stats_count_videos(media_client):
+    stats = media_client.get(f"{API}/stats").json()
+    assert stats["total_videos"] == 2
+    assert stats["total_images"] == 10
+
+
+# -- migration ---------------------------------------------------------------
+
+def test_old_library_gains_media_columns_in_place(indexed_service, library):
+    """A pre-video library is upgraded by add_columns, not a re-index."""
+    from photolib.browse import Filters
+    from photolib.service import PhotoService
+
+    images_before = library.images.count_rows(None)
+    library.images.drop_columns(["media_type", "duration_ms"])
+    assert "media_type" not in library.images.schema.names
+
+    # Constructing a service is the normal migration trigger.
+    fresh = PhotoService(settings=indexed_service.settings, library=library)
+    assert "media_type" in library.images.schema.names
+    assert library.images.count_rows(None) == images_before
+
+    page = fresh.search(None, Filters(media="image"))
+    assert page.total == images_before  # every legacy row is an image
+
+
+def test_browse_tolerates_an_unmigrated_library(indexed_service, library):
+    """Read-only browsing must not require the migration write."""
+    from photolib.browse import Filters, LibraryIndex
+
+    library.images.drop_columns(["media_type", "duration_ms"])
+    index = LibraryIndex(library)
+    index.ensure_fresh()
+    assert index.select(Filters(media="video")).size == 0
+    assert index.select(Filters()).size == 8
+
+
+# -- AVIF ---------------------------------------------------------------------
+
+def test_avif_files_are_indexed(indexer, indexed_service, photo_dir):
+    from photolib.browse import Filters
+    from photolib.imageio import avif_supported
+
+    if not avif_supported():
+        pytest.skip("this Pillow build lacks AVIF support")
+
+    from PIL import Image
+
+    array = np.zeros((60, 80, 3), dtype=np.uint8)
+    array[:, :] = (90, 140, 210)
+    Image.fromarray(array).save(photo_dir / "harbor-boats-morning.avif")
+
+    indexer.index_directory(photo_dir)
+    indexed_service.index.invalidate()
+    page = indexed_service.search("harbor boats morning", Filters(),
+                                  sort="relevance")
+    assert page.results[0]["filename"] == "harbor-boats-morning.avif"
+    assert page.results[0]["media_type"] == "image"

--- a/tests/test_packaging_config.py
+++ b/tests/test_packaging_config.py
@@ -22,3 +22,11 @@ def test_tracked_desktop_ui_is_the_real_app_not_a_placeholder():
     html = (ROOT / "desktop" / "ui" / "index.html").read_text(encoding="utf-8")
     assert 'id="folderPath"' in html
     assert 'src="/app.js"' in html
+
+
+def test_frozen_build_bundles_the_video_decoder():
+    """imageio-ffmpeg's data files carry the ffmpeg exe; losing them from
+    the spec would silently ship a build that skips every video."""
+    spec = (ROOT / "packaging" / "photolib.spec").read_text(encoding="utf-8")
+    assert 'collect_data_files("imageio_ffmpeg")' in spec
+    assert '"imageio_ffmpeg"' in spec  # hiddenimport


### PR DESCRIPTION
## What this adds

**Videos are now part of the library.** A video is represented by a poster frame pulled from ~1s in, and that frame flows through the exact same pipeline as a photo — SigLIP embedding, face detection, perceptual hash, OCR, thumbnails. That one design decision means search, people, albums, duplicates, multi-select, trash, and curation backup all work on videos with no new code paths.

- **Indexing**: 12 container formats (`.mp4 .mov .m4v .webm .mkv .avi .3gp .mpg .mpeg .wmv .mts .m2ts`) via the ffmpeg bundled in `imageio-ffmpeg`. Duration and capture time (container `creation_time`, converted UTC → local, with the filename-date fallback) are stored per video.
- **No re-index needed**: the `images` table gains `media_type` + `duration_ms` through an in-place `add_columns` migration that runs on service startup. Your next "Rescan all" simply discovers videos as new files.
- **Playback**: native `<video>` player in the viewer with scrubbing (the file endpoint serves HTTP Range → 206), volume, and fullscreen. If a codec is missing (e.g. HEVC without the Windows extension), the poster shows with an "open the original" fallback instead of a black box.
- **UI**: ▶ duration badge on tiles, a Photos/Videos filter, video count in the header stats.

**Keyboard shortcuts** — press `?` for the cheat sheet: `Delete` trashes the selection or open photo (two-step, Recycle Bin as always), `Ctrl+A` selects the page, `+`/`−`/`0` zoom the viewer, `Space` plays/pauses a video.

**Getting things out**:
- *Copy image* in the viewer — puts a PNG on the clipboard, works for HEIC/RAW too since it copies the decoded preview.
- *Show in Explorer* — opens the original, selected, in the file manager.
- *Export copies…* on the selection bar — copies originals into a folder you pick. Never moves or overwrites anything; name collisions get "(2)"-style suffixes.

**AVIF** — indexed natively through Pillow ≥ 11.2 (gated on a runtime codec check).

## Verified live

Against the real 2,8xx-photo library: startup migrated the images table in place, an incremental rescan indexed all 26 videos in your Pictures folder in under 2 minutes, video search/filter returns them with correct durations, a 130 MB video serves `206 Partial Content` for seeking, and poster thumbnails render in the grid. The dev server at http://127.0.0.1:8899 is running this branch now.

## Tests

240 pass (23 new): video indexing/metadata/probe, Range requests, poster thumbnails, media filter, the schema migration (including read-only browse of an unmigrated library), reveal/export (with a stubbed Explorer seam), export collision renaming, AVIF end-to-end, and a packaging guard so the frozen build can never silently lose the ffmpeg binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016tme4Q3rGCXL333C8vyxba